### PR TITLE
Reimplement the whole operations pipeline from multithreaded synchronous code to asynchronous code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,13 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+find_package(Boost REQUIRED)
 find_package(fmt REQUIRED)
 find_package(libfuse REQUIRED)
 find_package(rapidhash REQUIRED)
 find_package(spdlog REQUIRED)
-find_package(Boost REQUIRED)
 
-include(cmake/fetched-libs.cmake) # shared_futex
+include(cmake/fetched-libs.cmake) # saf
 
 add_library(adbfsm-lib STATIC)
 target_sources(
@@ -40,7 +40,7 @@ target_link_libraries(
         fmt::fmt
         libfuse::libfuse
         rapidhash::rapidhash
-        shared_futex
+        saf
         spdlog::spdlog
 )
 target_include_directories(adbfsm-lib PUBLIC include)
@@ -50,8 +50,10 @@ target_link_libraries(adbfsm PRIVATE adbfsm-lib)
 target_compile_options(adbfsm PRIVATE -Wall -Wextra -Wconversion)
 
 # # sanitizer
-# target_compile_options(adbfsm PRIVATE -fsanitize=address,leak,undefined)
-# target_link_options(adbfsm PRIVATE -fsanitize=address,leak,undefined)
+# # target_compile_options(adbfsm PRIVATE -fsanitize=address,leak,undefined)
+# # target_link_options(adbfsm PRIVATE -fsanitize=address,leak,undefined)
+# target_compile_options(adbfsm PRIVATE -fsanitize=address,undefined)
+# target_link_options(adbfsm PRIVATE -fsanitize=address,undefined)
 
 if(ADBFSM_ENABLE_TESTS)
     message(STATUS "Building tests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(fmt REQUIRED)
 find_package(libfuse REQUIRED)
-find_package(nlohmann_json REQUIRED)
 find_package(rapidhash REQUIRED)
-find_package(reproc++ REQUIRED)
 find_package(spdlog REQUIRED)
+find_package(Boost REQUIRED)
 
-include(cmake/fetched-libs.cmake)
+include(cmake/fetched-libs.cmake) # shared_futex
 
 add_library(adbfsm-lib STATIC)
 target_sources(
@@ -37,12 +36,10 @@ target_sources(
 target_link_libraries(
     adbfsm-lib
     PUBLIC
-        Sockpp::sockpp
+        boost::boost
         fmt::fmt
         libfuse::libfuse
-        nlohmann_json::nlohmann_json
         rapidhash::rapidhash
-        reproc::reproc
         shared_futex
         spdlog::spdlog
 )

--- a/cmake/fetched-libs.cmake
+++ b/cmake/fetched-libs.cmake
@@ -13,15 +13,3 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(shared_futex)
 # --------------------
-
-# target: Sockpp::sockpp
-# -----------------------
-set(SOCKPP_BUILD_STATIC ON)
-
-FetchContent_Declare(
-    sockpp
-    GIT_REPOSITORY https://github.com/fpagliughi/sockpp
-    GIT_TAG afdeacba9448c7a77194eed6ab8e1c0b1653c79a
-)
-FetchContent_MakeAvailable(sockpp)
-# -----------------------

--- a/cmake/fetched-libs.cmake
+++ b/cmake/fetched-libs.cmake
@@ -2,14 +2,14 @@ set(FETCHCONTENT_QUIET FALSE)
 
 include(FetchContent)
 
-# target: shared_futex
+# target: saf
 # --------------------
 FetchContent_Declare(
-    shared_futex
+    saf
     SYSTEM
-    GIT_REPOSITORY https://github.com/mrizaln/shared_futex
-    GIT_TAG 0aaac10f126022312c26a1546bac06d7e81f3afc
+    GIT_REPOSITORY https://github.com/ashtum/saf
+    GIT_TAG 3643d80c9ce0eaec374416bd456637b07a90b4d4
     GIT_PROGRESS TRUE
 )
-FetchContent_MakeAvailable(shared_futex)
+FetchContent_MakeAvailable(saf)
 # --------------------

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,11 +6,10 @@ class Recipe(ConanFile):
     settings = ["os", "compiler", "build_type", "arch"]
     generators = ["CMakeToolchain", "CMakeDeps"]
     requires = [
+        "boost/1.87.0",
         "fmt/11.0.2",
         "libfuse/3.16.2",
-        "nlohmann_json/3.12.0",
         "rapidhash/1.0",
-        "reproc/14.2.5",
         "spdlog/1.15.0",
     ]
     test_requires = ["boost-ext-ut/1.1.9"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,10 +7,10 @@ class Recipe(ConanFile):
     generators = ["CMakeToolchain", "CMakeDeps"]
     requires = [
         "boost/1.87.0",
-        "fmt/11.0.2",
+        "fmt/11.1.3",
         "libfuse/3.16.2",
         "rapidhash/1.0",
-        "spdlog/1.15.0",
+        "spdlog/1.15.1",
     ]
     test_requires = ["boost-ext-ut/1.1.9"]
 

--- a/include/adbfsm/adbfsm.hpp
+++ b/include/adbfsm/adbfsm.hpp
@@ -13,18 +13,21 @@ namespace adbfsm
     class Adbfsm
     {
     public:
-        Adbfsm(Uniq<data::IConnection> connection, Uniq<data::Cache> cache);
+        Adbfsm(usize page_size, usize max_pages);
+        ~Adbfsm();
 
         tree::FileTree&    tree() { return m_tree; }
-        const data::Cache& cache() const { return *m_cache; }
+        async::Context&    async_ctx() { return m_async_ctx; }
+        const data::Cache& cache() const { return m_cache; }
 
     private:
-        nlohmann::json ipc_handler(data::ipc::Op op);
+        boost::json::value ipc_handler(data::ipc::Op op);
 
+        async::Context          m_async_ctx;
         Uniq<data::IConnection> m_connection;
-        Uniq<data::Cache>       m_cache;
+        data::Cache             m_cache;
         tree::FileTree          m_tree;
-        Opt<data::Ipc>          m_ipc;
+        Uniq<data::Ipc>         m_ipc;
     };
 
     void* init(fuse_conn_info*, fuse_config*);

--- a/include/adbfsm/async/as_expected.hpp
+++ b/include/adbfsm/async/as_expected.hpp
@@ -1,0 +1,202 @@
+#pragma once
+
+/// custom completion token for Asio coroutines
+/// inspiration:
+/// https://gist.github.com/cstratopoulos/901b5cdd41d07c6ce6d83798b09ecf9b/863c1dbf3b063a5ff9ff2bdd834242ead556e74e
+
+#include <boost/asio.hpp>
+#include <boost/asio/detail/handler_alloc_helpers.hpp>
+
+#include <concepts>
+#include <expected>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+
+namespace adbfsm::async
+{
+    template <typename CompletionToken>
+    struct AsExpected
+    {
+        struct DefaultConstructorTag
+        {
+        };
+
+        // default constructor
+        /**
+         * this constructor is only valid if the underlying completion token is default constructible and move
+         * constructible. the underlying completion token is itself defaulted as an argument to allow it to
+         * capture a source location.
+         */
+        constexpr AsExpected(
+            DefaultConstructorTag = DefaultConstructorTag{},
+            CompletionToken token = CompletionToken{}    //
+        )
+            : m_token(std::move(token))
+        {
+        }
+
+        // constructor
+        template <typename T>
+        constexpr explicit AsExpected(T&& completion_token)
+            : m_token(std::forward<T>(completion_token))
+        {
+        }
+
+        // adapts an executor to add the as_expected_t completion token as the default.
+        template <typename InnerExecutor>
+        struct ExecutorWithDefault : InnerExecutor
+        {
+            // NOTE: integration with Asio; keep don't change the name
+            using default_completion_token_type = AsExpected;
+
+            // Construct the adapted executor from the inner executor type.
+            template <typename InnerExecutor1>
+                requires (!std::same_as<InnerExecutor1, ExecutorWithDefault> && std::convertible_to<InnerExecutor1, InnerExecutor>)
+            ExecutorWithDefault(InnerExecutor1&& ex) noexcept
+                : InnerExecutor(std::forward<InnerExecutor1>(ex))
+            {
+            }
+        };
+
+        // Type alias to adapt an I/O object to use as_expected_t as its default completion token type.
+        // NOTE: integration with Asio. you can change the name, but it would be better if not
+        template <typename T>
+        using as_default_on_t
+            = T::template rebind_executor<ExecutorWithDefault<typename T::executor_type>>::other;
+
+        // function helper to adapt an I/O object to use as_expected_t as its default completion token type.
+        // NOTE: integration with Asio. you can change the name, but it would be better if not
+        template <typename T>
+        static std::decay_t<T>::template rebind_executor<
+            ExecutorWithDefault<typename std::decay_t<T>::executor_type>>::other
+        as_default_on(T&& object)
+        {
+            return std::decay_t<T>::template rebind_executor<
+                ExecutorWithDefault<typename std::decay_t<T>::executor_type>>::other(std::forward<T>(object));
+        }
+        CompletionToken m_token;
+    };
+
+    namespace detail
+    {
+
+        template <typename T, typename... Ts>
+        concept AnyOf = (std::same_as<T, Ts> || ...);
+
+        template <typename T>
+        concept Error = AnyOf<T, std::error_code, const std::error_code&, std::exception_ptr>;
+
+        // Class to adapt as_expected_t as a completion handler
+        template <typename Handler>
+        struct ExpectedHandler
+        {
+            template <Error E>
+            void operator()(E e)
+            {
+                using Result = std::expected<void, std::remove_cvref_t<E>>;
+
+                if (e) {
+                    m_handler(Result{ std::unexpected(e) });
+                } else {
+                    m_handler(Result{});
+                }
+            }
+
+            template <typename T, Error E>
+            void operator()(E e, T t)
+            {
+                using Result = std::expected<T, std::remove_cvref_t<E>>;
+
+                if (e) {
+                    m_handler(Result{ std::unexpected(e) });
+                } else {
+                    m_handler(Result{ std::move(t) });
+                }
+            }
+
+            Handler m_handler;
+        };
+
+        template <typename Signature>
+        struct ExpectedSignatureTrait;
+
+        template <Error E>
+        struct ExpectedSignatureTrait<void(E)>
+        {
+            using type = void(std::expected<void, E>);
+        };
+
+        template <typename T, Error E>
+        struct ExpectedSignatureTrait<void(E, T)>
+        {
+            using type = void(std::expected<T, E>);
+        };
+
+        template <typename Signature>
+        using ExpectedSignatureTrait_t = ExpectedSignatureTrait<Signature>::type;
+
+    }    // namespace detail
+
+}    // namespace async
+
+// NOTE: any partial specialization here are for integration with Asio, don't change the name of it. some
+// typedef also for integration and have a fixed name
+namespace boost::asio
+{
+
+    template <typename T>
+    using ExpectedHandler = adbfsm::async::detail::ExpectedHandler<T>;
+
+    template <typename CompletionToken, typename Signature>
+    class async_result<adbfsm::async::AsExpected<CompletionToken>, Signature>
+    {
+    private:
+        using ExpectedSignature = adbfsm::async::detail::ExpectedSignatureTrait_t<Signature>;
+        using ReturnType        = async_result<CompletionToken, ExpectedSignature>::return_type;
+
+    public:
+        template <typename Initiation, typename... Args>
+        static ReturnType initiate(
+            Initiation&&                                 initiation,
+            adbfsm::async::AsExpected<CompletionToken>&& token,
+            Args&&... args
+        )
+        {
+            return async_initiate<CompletionToken, ExpectedSignature>(
+                [init = std::forward<Initiation>(initiation)]<typename Handler, typename... CArgs>(
+                    Handler&& handler, CArgs&&... callArgs    //
+                ) mutable {
+                    std::move(init)(
+                        ExpectedHandler<Handler>{ std::forward<Handler>(handler) },
+                        std::forward<CArgs>(callArgs)...    //
+                    );
+                },
+                token.m_token,
+                std::forward<Args>(args)...
+            );
+        }
+    };
+
+    template <typename Handler, typename Executor>
+    struct associated_executor<ExpectedHandler<Handler>, Executor>
+    {
+        using type = associated_executor<Handler, Executor>::type;
+
+        static type get(const ExpectedHandler<Handler>& h, const Executor& ex = Executor()) noexcept
+        {
+            return associated_executor<Handler, Executor>::get(h.m_handler, ex);
+        }
+    };
+
+    template <typename Handler, typename Allocator>
+    struct associated_allocator<ExpectedHandler<Handler>, Allocator>
+    {
+        using type = associated_allocator<Handler, Allocator>::type;
+
+        static type get(const ExpectedHandler<Handler>& h, const Allocator& a = Allocator()) noexcept
+        {
+            return associated_allocator<Handler, Allocator>::get(h.m_handler, a);
+        }
+    };
+}    // namespace asio

--- a/include/adbfsm/async/as_expected.hpp
+++ b/include/adbfsm/async/as_expected.hpp
@@ -9,7 +9,6 @@
 
 #include <concepts>
 #include <expected>
-#include <system_error>
 #include <type_traits>
 #include <utility>
 
@@ -80,12 +79,12 @@ namespace adbfsm::async
 
     namespace detail
     {
-
         template <typename T, typename... Ts>
         concept AnyOf = (std::same_as<T, Ts> || ...);
 
         template <typename T>
-        concept Error = AnyOf<T, std::error_code, const std::error_code&, std::exception_ptr>;
+        concept Error
+            = AnyOf<T, boost::system::error_code, const boost::system::error_code&, std::exception_ptr>;
 
         // Class to adapt as_expected_t as a completion handler
         template <typename Handler>

--- a/include/adbfsm/async/async.hpp
+++ b/include/adbfsm/async/async.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "adbfsm/async/as_expected.hpp"
+#include "adbfsm/common.hpp"
 
 #include <boost/asio.hpp>
 #include <boost/asio/error.hpp>
@@ -9,71 +10,81 @@
 #include <expected>
 #include <utility>
 
+namespace adbfsm
+{
+    template <typename T>
+    using Await = boost::asio::awaitable<T>;
+
+    template <typename T>
+    using AExpect = Await<Expect<T>>;
+}
+
 namespace adbfsm::async
 {
     using Context  = boost::asio::io_context;
     using Token    = AsExpected<boost::asio::use_awaitable_t<>>;
     using Executor = Context::executor_type;
 
-    template <typename T>
-    using Await = boost::asio::awaitable<T>;
-
     template <typename Exec, typename Awaited, typename Completion>
     auto spawn(Exec&& ex, Awaited&& func, Completion&& completion)
     {
-        return co_spawn(
-            std::forward<Exec>(ex),    //
-            std::forward<Awaited>(func),
-            std::forward<Completion>(completion)
+        return boost::asio::co_spawn(
+            std::forward<Exec>(ex), std::forward<Awaited>(func), std::forward<Completion>(completion)
         );
     }
 
-    inline std::errc to_generic_err(boost::system::error_code ec, std::errc fallback = std::errc::io_error)
+    inline Errc to_generic_err(boost::system::error_code ec, Errc fallback = Errc::io_error)
     {
         if (ec.category() == boost::system::generic_category()) {
-            return static_cast<std::errc>(ec.value());
+            return static_cast<Errc>(ec.value());
         }
-        return static_cast<bool>(fallback) ? fallback : std::errc::invalid_argument;
+        return static_cast<bool>(fallback) ? fallback : Errc::invalid_argument;
     }
 
     template <typename AStream>
-    Await<std::pair<boost::system::error_code, std::size_t>> write_all(AStream& stream, std::string_view buf)
+    Await<Pair<boost::system::error_code, usize>> write_exact(AStream& stream, Span<const char> in)
     {
         auto written = 0uz;
-        while (written < buf.size()) {
-            auto buffer = boost::asio::buffer(buf.data() + written, buf.size() - written);
+        while (written < in.size()) {
+            auto buffer = boost::asio::buffer(in.data() + written, in.size() - written);
             auto res    = co_await stream.async_write_some(buffer);
             if (not res) {
-                co_return std::pair{ res.error(), written };
+                co_return Pair{ res.error(), written };
             }
             auto len = *res;
             if (len == 0) {
-                co_return std::pair{ std::make_error_code(std::errc::broken_pipe), written };
+                co_return Pair{ std::make_error_code(Errc::broken_pipe), written };
             }
             written += len;
         }
-        co_return std::pair{ std::error_code{}, written };
+        co_return Pair{ std::error_code{}, written };
     }
 
     template <typename AStream>
-    Await<std::pair<boost::system::error_code, std::size_t>> read_all(AStream& stream, std::string& buf)
+    Await<Pair<boost::system::error_code, usize>> read_exact(AStream& stream, Span<char> out)
     {
-        auto dyn_buf = boost::asio::dynamic_buffer(buf);
-        while (true) {
-            auto res = co_await stream.async_read_some(dyn_buf);
-            if (res) {
-                continue;
+        auto read = 0uz;
+        while (read < out.size()) {
+            auto buffer = boost::asio::buffer(out.data() + read, out.size() - read);
+            auto res    = co_await stream.async_read_some(buffer);
+            if (not res) {
+                co_return Pair{ res.error(), read };
             }
-            if (res.error() == boost::asio::error::eof) {
-                break;
+            auto len = *res;
+            if (len == 0) {
+                co_return Pair{ std::make_error_code(Errc::broken_pipe), read };
             }
-            co_return std::pair{ res.error(), dyn_buf.size() };
+            read += len;
         }
-        co_return std::pair{ std::error_code{}, dyn_buf.size() };
+        co_return Pair{ std::error_code{}, read };
     }
 
     using boost::asio::buffer;
     using boost::asio::dynamic_buffer;
+
+    using boost::asio::detached;
+    using boost::asio::use_awaitable;
+    using boost::asio::use_future;
 
     namespace this_coro = boost::asio::this_coro;
     namespace operators = boost::asio::experimental::awaitable_operators;
@@ -81,6 +92,7 @@ namespace adbfsm::async
     namespace unix_socket
     {
         using Proto    = boost::asio::local::stream_protocol;
+        using Endpoint = Proto::endpoint;
         using Acceptor = Token::as_default_on_t<Proto::acceptor>;
         using Socket   = Token::as_default_on_t<Proto::socket>;
     }

--- a/include/adbfsm/async/async.hpp
+++ b/include/adbfsm/async/async.hpp
@@ -3,6 +3,7 @@
 #include "adbfsm/async/as_expected.hpp"
 
 #include <boost/asio.hpp>
+#include <boost/asio/error.hpp>
 #include <boost/asio/experimental/awaitable_operators.hpp>
 
 #include <expected>
@@ -27,6 +28,53 @@ namespace adbfsm::async
         );
     }
 
+    inline std::errc to_generic_err(boost::system::error_code ec, std::errc fallback = std::errc::io_error)
+    {
+        if (ec.category() == boost::system::generic_category()) {
+            return static_cast<std::errc>(ec.value());
+        }
+        return static_cast<bool>(fallback) ? fallback : std::errc::invalid_argument;
+    }
+
+    template <typename AStream>
+    Await<std::pair<boost::system::error_code, std::size_t>> write_all(AStream& stream, std::string_view buf)
+    {
+        auto written = 0uz;
+        while (written < buf.size()) {
+            auto buffer = boost::asio::buffer(buf.data() + written, buf.size() - written);
+            auto res    = co_await stream.async_write_some(buffer);
+            if (not res) {
+                co_return std::pair{ res.error(), written };
+            }
+            auto len = *res;
+            if (len == 0) {
+                co_return std::pair{ std::make_error_code(std::errc::broken_pipe), written };
+            }
+            written += len;
+        }
+        co_return std::pair{ std::error_code{}, written };
+    }
+
+    template <typename AStream>
+    Await<std::pair<boost::system::error_code, std::size_t>> read_all(AStream& stream, std::string& buf)
+    {
+        auto dyn_buf = boost::asio::dynamic_buffer(buf);
+        while (true) {
+            auto res = co_await stream.async_read_some(dyn_buf);
+            if (res) {
+                continue;
+            }
+            if (res.error() == boost::asio::error::eof) {
+                break;
+            }
+            co_return std::pair{ res.error(), dyn_buf.size() };
+        }
+        co_return std::pair{ std::error_code{}, dyn_buf.size() };
+    }
+
+    using boost::asio::buffer;
+    using boost::asio::dynamic_buffer;
+
     namespace this_coro = boost::asio::this_coro;
     namespace operators = boost::asio::experimental::awaitable_operators;
 
@@ -35,5 +83,11 @@ namespace adbfsm::async
         using Proto    = boost::asio::local::stream_protocol;
         using Acceptor = Token::as_default_on_t<Proto::acceptor>;
         using Socket   = Token::as_default_on_t<Proto::socket>;
+    }
+
+    namespace pipe
+    {
+        using Write = Token::as_default_on_t<boost::asio::writable_pipe>;
+        using Read  = Token::as_default_on_t<boost::asio::readable_pipe>;
     }
 }

--- a/include/adbfsm/async/async.hpp
+++ b/include/adbfsm/async/async.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "adbfsm/async/as_expected.hpp"
+
+#include <boost/asio.hpp>
+#include <boost/asio/experimental/awaitable_operators.hpp>
+
+#include <expected>
+#include <utility>
+
+namespace adbfsm::async
+{
+    using Context  = boost::asio::io_context;
+    using Token    = AsExpected<boost::asio::use_awaitable_t<>>;
+    using Executor = Context::executor_type;
+
+    template <typename T>
+    using Await = boost::asio::awaitable<T>;
+
+    template <typename Exec, typename Awaited, typename Completion>
+    auto spawn(Exec&& ex, Awaited&& func, Completion&& completion)
+    {
+        return co_spawn(
+            std::forward<Exec>(ex),    //
+            std::forward<Awaited>(func),
+            std::forward<Completion>(completion)
+        );
+    }
+
+    namespace this_coro = boost::asio::this_coro;
+    namespace operators = boost::asio::experimental::awaitable_operators;
+
+    namespace unix_socket
+    {
+        using Proto    = boost::asio::local::stream_protocol;
+        using Acceptor = Token::as_default_on_t<Proto::acceptor>;
+        using Socket   = Token::as_default_on_t<Proto::socket>;
+    }
+}

--- a/include/adbfsm/data/connection.hpp
+++ b/include/adbfsm/data/connection.hpp
@@ -23,29 +23,26 @@ namespace adbfsm::data
     class IConnection
     {
     public:
-        template <typename T>
-        using Aresult = async::Await<Expect<T>>;
-
-        virtual Aresult<Gen<ParsedStat>> statdir(path::Path path)  = 0;
-        virtual Aresult<Stat>            stat(path::Path path)     = 0;
-        virtual Aresult<path::PathBuf>   readlink(path::Path path) = 0;
+        virtual AExpect<Gen<ParsedStat>> statdir(path::Path path)  = 0;
+        virtual AExpect<Stat>            stat(path::Path path)     = 0;
+        virtual AExpect<path::PathBuf>   readlink(path::Path path) = 0;
 
         // directory operations
-        virtual Aresult<void> mkdir(path::Path path)              = 0;
-        virtual Aresult<void> rm(path::Path path, bool recursive) = 0;
-        virtual Aresult<void> rmdir(path::Path path)              = 0;
-        virtual Aresult<void> mv(path::Path from, path::Path to)  = 0;
+        virtual AExpect<void> mkdir(path::Path path)              = 0;
+        virtual AExpect<void> rm(path::Path path, bool recursive) = 0;
+        virtual AExpect<void> rmdir(path::Path path)              = 0;
+        virtual AExpect<void> mv(path::Path from, path::Path to)  = 0;
 
         // file operations
-        virtual Aresult<void>  truncate(path::Path path, off_t size)                     = 0;
-        virtual Aresult<u64>   open(path::Path path, int flags)                          = 0;
-        virtual Aresult<usize> read(path::Path path, Span<char> out, off_t offset)       = 0;
-        virtual Aresult<usize> write(path::Path path, Span<const char> in, off_t offset) = 0;
-        virtual Aresult<void>  flush(path::Path path)                                    = 0;
-        virtual Aresult<void>  release(path::Path path)                                  = 0;
+        virtual AExpect<void>  truncate(path::Path path, off_t size)                     = 0;
+        virtual AExpect<u64>   open(path::Path path, int flags)                          = 0;
+        virtual AExpect<usize> read(path::Path path, Span<char> out, off_t offset)       = 0;
+        virtual AExpect<usize> write(path::Path path, Span<const char> in, off_t offset) = 0;
+        virtual AExpect<void>  flush(path::Path path)                                    = 0;
+        virtual AExpect<void>  release(path::Path path)                                  = 0;
 
         // directory operation (adding file) or file operation (update time)
-        virtual Aresult<void> touch(path::Path path, bool create) = 0;
+        virtual AExpect<void> touch(path::Path path, bool create) = 0;
 
         virtual ~IConnection() = default;
     };
@@ -69,7 +66,7 @@ namespace adbfsm::data
          *
          * @return A generator if successful, or an error if it fails.
          */
-        Aresult<Gen<ParsedStat>> statdir(path::Path path) override;
+        AExpect<Gen<ParsedStat>> statdir(path::Path path) override;
 
         /**
          * @brief Get the stat of a file or directory.
@@ -78,21 +75,21 @@ namespace adbfsm::data
          *
          * @return The stat of the file or directory.
          */
-        Aresult<Stat> stat(path::Path path) override;
+        AExpect<Stat> stat(path::Path path) override;
 
         /**
          * @brief Get the real file pointed by a symlink.
          *
          * @param path The path to the file or directory.
          */
-        Aresult<path::PathBuf> readlink(path::Path path) override;
+        AExpect<path::PathBuf> readlink(path::Path path) override;
 
         /**
          * @brief Make a directory on the device.
          *
          * @param path Path to the directory.
          */
-        Aresult<void> mkdir(path::Path path) override;
+        AExpect<void> mkdir(path::Path path) override;
 
         /**
          * @brief Remove a file on the device.
@@ -100,14 +97,14 @@ namespace adbfsm::data
          * @param path Path to the file on the device.
          * @param bool Whether to remove recursively or not.
          */
-        Aresult<void> rm(path::Path path, bool recursive) override;
+        AExpect<void> rm(path::Path path, bool recursive) override;
 
         /**
          * @brief Remove a directory on the device.
          *
          * @param path Path to the directory on the device.
          */
-        Aresult<void> rmdir(path::Path path) override;
+        AExpect<void> rmdir(path::Path path) override;
 
         /**
          * @brief Move a file on the device.
@@ -115,7 +112,7 @@ namespace adbfsm::data
          * @param from Target file.
          * @param to Destination file.
          */
-        Aresult<void> mv(path::Path from, path::Path to) override;
+        AExpect<void> mv(path::Path from, path::Path to) override;
 
         // --------------------
 
@@ -128,7 +125,7 @@ namespace adbfsm::data
          * @param path Path to the file on the device.
          * @param size Size to truncate to.
          */
-        Aresult<void> truncate(path::Path path, off_t size) override;
+        AExpect<void> truncate(path::Path path, off_t size) override;
 
         /**
          * @brief Open a file on the device.
@@ -136,7 +133,7 @@ namespace adbfsm::data
          * @param path Path to the file on the device.
          * @param flags Flags to open the file with.
          */
-        Aresult<u64> open(path::Path path, int flags) override;
+        AExpect<u64> open(path::Path path, int flags) override;
 
         /**
          * @brief Read from a file on the device.
@@ -145,7 +142,7 @@ namespace adbfsm::data
          * @param out Buffer to read into.
          * @param offset Offset to read from.
          */
-        Aresult<usize> read(path::Path path, Span<char> out, off_t offset) override;
+        AExpect<usize> read(path::Path path, Span<char> out, off_t offset) override;
 
         /**
          * @brief Write to a file on the device.
@@ -154,21 +151,21 @@ namespace adbfsm::data
          * @param in Buffer to write from.
          * @param offset Offset to write to.
          */
-        Aresult<usize> write(path::Path path, Span<const char> in, off_t offset) override;
+        AExpect<usize> write(path::Path path, Span<const char> in, off_t offset) override;
 
         /**
          * @brief Flush a file on the device.
          *
          * @param path Path to the file on the device.
          */
-        Aresult<void> flush(path::Path path) override;
+        AExpect<void> flush(path::Path path) override;
 
         /**
          * @brief Release a file on the device.
          *
          * @param path Path to the file on the device.
          */
-        Aresult<void> release(path::Path path) override;
+        AExpect<void> release(path::Path path) override;
 
         // ---------------
 
@@ -178,7 +175,7 @@ namespace adbfsm::data
          * @param path Path to the file.
          * @param create Indicate whether to create a file if not exist.
          */
-        Aresult<void> touch(path::Path path, bool create) override;
+        AExpect<void> touch(path::Path path, bool create) override;
 
     private:
         async::Context&  m_context;
@@ -214,10 +211,10 @@ namespace adbfsm::data
     /**
      * @brief Start connection with the devices.
      */
-    Connection::Aresult<void> start_connection();
+    AExpect<void> start_connection();
 
     /**
      * @brief List connected devices.
      */
-    Connection::Aresult<Vec<Device>> list_devices();
+    AExpect<Vec<Device>> list_devices();
 }

--- a/include/adbfsm/tree/file_tree.hpp
+++ b/include/adbfsm/tree/file_tree.hpp
@@ -35,24 +35,24 @@ namespace adbfsm::tree
          */
         Expect<Ref<Node>> traverse(path::Path path);
 
-        Expect<void>                  readdir(path::Path path, Filler filler);
-        Expect<Ref<const data::Stat>> getattr(path::Path path);
+        AExpect<void>                  readdir(path::Path path, Filler filler);
+        AExpect<Ref<const data::Stat>> getattr(path::Path path);
 
-        Expect<Ref<Node>> readlink(path::Path path);
-        Expect<Ref<Node>> mknod(path::Path path);
-        Expect<Ref<Node>> mkdir(path::Path path);
-        Expect<void>      unlink(path::Path path);
-        Expect<void>      rmdir(path::Path path);
-        Expect<void>      rename(path::Path from, path::Path to);
+        AExpect<Ref<Node>> readlink(path::Path path);
+        AExpect<Ref<Node>> mknod(path::Path path);
+        AExpect<Ref<Node>> mkdir(path::Path path);
+        AExpect<void>      unlink(path::Path path);
+        AExpect<void>      rmdir(path::Path path);
+        AExpect<void>      rename(path::Path from, path::Path to);
 
-        Expect<void>  truncate(path::Path path, off_t size);
-        Expect<u64>   open(path::Path path, int flags);
-        Expect<usize> read(path::Path path, u64 fd, Span<char> out, off_t offset);
-        Expect<usize> write(path::Path path, u64 fd, Str in, off_t offset);
-        Expect<void>  flush(path::Path path, u64 fd);
-        Expect<void>  release(path::Path path, u64 fd);
+        AExpect<void>  truncate(path::Path path, off_t size);
+        AExpect<u64>   open(path::Path path, int flags);
+        AExpect<usize> read(path::Path path, u64 fd, Span<char> out, off_t offset);
+        AExpect<usize> write(path::Path path, u64 fd, Str in, off_t offset);
+        AExpect<void>  flush(path::Path path, u64 fd);
+        AExpect<void>  release(path::Path path, u64 fd);
 
-        Expect<void> utimens(path::Path path);
+        AExpect<void> utimens(path::Path path);
 
         // this function only used to link already existing files, user can't use it
         Expect<void> symlink(path::Path path, path::Path target);
@@ -65,7 +65,7 @@ namespace adbfsm::tree
          *
          * @param path Path to the node.
          */
-        Expect<Ref<Node>> traverse_or_build(path::Path path);
+        AExpect<Ref<Node>> traverse_or_build(path::Path path);
 
         Node               m_root;
         data::IConnection& m_connection;

--- a/include/adbfsm/tree/node.hpp
+++ b/include/adbfsm/tree/node.hpp
@@ -6,7 +6,6 @@
 #include "adbfsm/data/stat.hpp"
 #include "adbfsm/path/path.hpp"
 
-#include <shared_futex/shared_futex.hpp>
 #include <sys/types.h>
 
 #include <algorithm>
@@ -300,7 +299,7 @@ namespace adbfsm::tree
          *
          * @return The new regular file node.
          */
-        Expect<Ref<Node>> touch(Context context, Str name);
+        AExpect<Ref<Node>> touch(Context context, Str name);
 
         /**
          * @brief Create a new child node as Directory.
@@ -310,7 +309,7 @@ namespace adbfsm::tree
          *
          * @return The new directory node.
          */
-        Expect<Ref<Node>> mkdir(Context context, Str name);
+        AExpect<Ref<Node>> mkdir(Context context, Str name);
 
         /**
          * @brief Remove a child node by its name (RegularFile or Directory).
@@ -319,7 +318,7 @@ namespace adbfsm::tree
          * @param name The name of the child node.
          * @param recursive Whether to remove recursively or not.
          */
-        Expect<void> rm(Context context, Str name, bool recursive);
+        AExpect<void> rm(Context context, Str name, bool recursive);
 
         /**
          * @brief Remove a child node by its name (Directory).
@@ -327,7 +326,7 @@ namespace adbfsm::tree
          * @param context Context needed to communicate with device and local.
          * @param name The name of the child node.
          */
-        Expect<void> rmdir(Context context, Str name);
+        AExpect<void> rmdir(Context context, Str name);
 
         // -----------------------
 
@@ -340,7 +339,7 @@ namespace adbfsm::tree
          * @param context Context needed to communicate with device and local.
          * @param size The final size to truncate to.
          */
-        Expect<void> truncate(Context context, off_t size);
+        AExpect<void> truncate(Context context, off_t size);
 
         /**
          * @brief Open file.
@@ -350,7 +349,7 @@ namespace adbfsm::tree
          *
          * @return File descriptor.
          */
-        Expect<u64> open(Context context, int flags);
+        AExpect<u64> open(Context context, int flags);
 
         /**
          * @brief Read data from file.
@@ -362,7 +361,7 @@ namespace adbfsm::tree
          *
          * @return The number of bytes read.
          */
-        Expect<usize> read(Context context, u64 fd, Span<char> out, off_t offset);
+        AExpect<usize> read(Context context, u64 fd, Span<char> out, off_t offset);
 
         /**
          * @brief Write data to file.
@@ -374,7 +373,7 @@ namespace adbfsm::tree
          *
          * @return The number of bytes written.
          */
-        Expect<usize> write(Context context, u64 fd, Str in, off_t offset);
+        AExpect<usize> write(Context context, u64 fd, Str in, off_t offset);
 
         /**
          * @brief Flush buffer of the file.
@@ -384,21 +383,21 @@ namespace adbfsm::tree
          *
          * Basically forcing writing to the file itself instead of to the buffer in memory.
          */
-        Expect<void> flush(Context context, u64 fd);
+        AExpect<void> flush(Context context, u64 fd);
 
         /**
          * @brief Release file.
          *
          * @param context Context needed to communicate with device and local.
          */
-        Expect<void> release(Context context, u64 fd);
+        AExpect<void> release(Context context, u64 fd);
 
         /**
          * @brief Update the timestamps of a file.
          *
          * @param context Context needed to communicate with device and local.
          */
-        Expect<void> utimens(Context context);
+        AExpect<void> utimens(Context context);
 
         // -------------------------
 
@@ -448,9 +447,6 @@ namespace adbfsm::tree
         String     m_name   = {};
         data::Stat m_stat   = {};
         File       m_value;
-
-        mutable strt::shared_futex_micro m_mutex;
-        mutable strt::shared_futex_micro m_mutex_file;
     };
 }
 

--- a/source/adbfsm.cpp
+++ b/source/adbfsm.cpp
@@ -6,19 +6,42 @@
 #include "adbfsm/util/threadpool.hpp"
 
 #include <fcntl.h>
-#include <nlohmann/json.hpp>
 
 #include <cassert>
 #include <cstring>
 
 namespace
 {
-
     adbfsm::Adbfsm& get_data()
     {
         auto ctx = ::fuse_get_context()->private_data;
         assert(ctx != nullptr);
         return *static_cast<adbfsm::Adbfsm*>(ctx);
+    }
+
+    template <typename Ret, typename... Args>
+    auto tree_blocking(Ret (adbfsm::tree::FileTree::*fn)(Args...), std::type_identity_t<Args>... args)
+    {
+        // NOTE: for some reason con't use `use_future` as completion token, so I just implement it manually
+
+        auto& data = get_data();
+        auto& ctx  = data.async_ctx();
+        auto& tree = data.tree();
+
+        auto promise = std::promise<typename Ret::value_type>{};
+        auto fut     = promise.get_future();
+
+        adbfsm::async::spawn(
+            ctx,
+            [promise = std::move(promise), fn, &tree, ... args = std::forward<Args>(args)] mutable
+                -> adbfsm::Await<void> {
+                auto coro = (tree.*fn)(std::forward<Args>(args)...);
+                promise.set_value(co_await std::move(coro));
+            },
+            adbfsm::async::detached
+        );
+
+        return fut.get();
     }
 
     auto fuse_err(adbfsm::Str name, const char* path)
@@ -54,26 +77,39 @@ namespace
 
 namespace adbfsm
 {
-    Adbfsm::Adbfsm(Uniq<data::IConnection> connection, Uniq<data::Cache> cache)
-        : m_connection{ std::move(connection) }
-        , m_cache{ std::move(cache) }
-        , m_tree{ *m_connection, *m_cache }
+    Adbfsm::Adbfsm(usize page_size, usize max_pages)
+        : m_connection{ std::make_unique<data::Connection>(m_async_ctx, page_size) }
+        , m_cache{ page_size, max_pages }
+        , m_tree{ *m_connection, m_cache }
     {
-        auto ipc = data::Ipc::create();
+
+        log_d({ "{}: ctor of Adbfsm" }, __func__);
+
+        auto ipc = data::Ipc::create(m_async_ctx);
         if (not ipc.has_value()) {
             const auto msg = std::make_error_code(ipc.error()).message();
             log_e({ "Adbfsm: failed to initialize ipc: {}" }, msg);
             return;
         }
 
-        const auto path = ipc->path();
+        const auto path = (*ipc)->path();
         log_i({ "Adbfsm: succesfully created ipc: {}" }, path.fullpath());
         m_ipc = std::move(*ipc);
 
-        m_ipc->launch([this](data::ipc::Op op) { return ipc_handler(op); });
+        auto coro = m_ipc->launch([this](data::ipc::Op op) { return ipc_handler(op); });
+        async::spawn(m_async_ctx, std::move(coro), [](const std::exception_ptr& exceptionPtr) {
+            if (exceptionPtr) {
+                std::rethrow_exception(exceptionPtr);
+            }
+        });
     }
 
-    nlohmann::json Adbfsm::ipc_handler(data::ipc::Op op)
+    Adbfsm::~Adbfsm()
+    {
+        m_async_ctx.stop();
+    }
+
+    boost::json::value Adbfsm::ipc_handler(data::ipc::Op op)
     {
         namespace ipc = data::ipc;
 
@@ -83,50 +119,50 @@ namespace adbfsm
 
         auto overload = util::Overload{
             [&](ipc::Help) {
-                return nlohmann::json("not implemented yet :P");    // TODO: implement
+                return boost::json::value("not implemented yet :P");    // TODO: implement
             },
             [&](ipc::InvalidateCache) {
-                m_cache->invalidate();
-                return nlohmann::json{};
+                m_cache.invalidate();
+                return boost::json::value{};
             },
             [&](ipc::SetPageSize size) {
-                auto old_size = m_cache->page_size();
+                auto old_size = m_cache.page_size();
                 auto new_size = std::bit_ceil(size.kib * 1024);
                 new_size      = std::clamp(new_size, lowest_page_size, highest_page_size);
-                m_cache->set_page_size(new_size);
+                m_cache.set_page_size(new_size);
 
-                auto old_max = m_cache->max_pages();
+                auto old_max = m_cache.max_pages();
                 auto new_max = std::bit_ceil(old_max * old_size / new_size);
                 new_max      = std::max(new_max, lowest_max_pages);
-                m_cache->set_max_pages(new_max);
+                m_cache.set_max_pages(new_max);
 
-                auto json              = nlohmann::json{};
+                auto json              = boost::json::object{};
                 json["old_page_size"]  = old_size / 1024;
                 json["old_cache_size"] = old_max * old_size / 1024 / 1024;
                 json["new_page_size"]  = new_size / 1024;
                 json["new_cache_size"] = new_max * new_size / 1024 / 1024;
-                return json;
+                return boost::json::value{ json };
             },
             [&](ipc::GetPageSize) {
-                auto size = m_cache->page_size();
-                return nlohmann::json(size);
+                auto size = m_cache.page_size();
+                return boost::json::value(size);
             },
             [&](ipc::SetCacheSize size) {
-                auto page    = m_cache->page_size();
-                auto old_max = m_cache->max_pages();
+                auto page    = m_cache.page_size();
+                auto old_max = m_cache.max_pages();
                 auto new_max = std::bit_ceil(size.mib * 1024 * 1024 / page);
                 new_max      = std::max(new_max, lowest_max_pages);
-                m_cache->set_max_pages(new_max);
+                m_cache.set_max_pages(new_max);
 
-                auto json              = nlohmann::json{};
+                auto json              = boost::json::object{};
                 json["old_cache_size"] = old_max * page / 1024 / 1024;
                 json["new_cache_size"] = new_max * page / 1024 / 1024;
-                return json;
+                return boost::json::value{ json };
             },
             [&](ipc::GetCacheSize) {
-                auto page      = m_cache->page_size();
-                auto num_pages = m_cache->max_pages();
-                return nlohmann::json(page * num_pages / 1024 / 1024);
+                auto page      = m_cache.page_size();
+                auto num_pages = m_cache.max_pages();
+                return boost::json::value(page * num_pages / 1024 / 1024);
             },
         };
         return std::visit(overload, op);
@@ -143,10 +179,16 @@ namespace adbfsm
 
         util::Threadpool::init();
 
-        return new Adbfsm{
-            std::make_unique<data::Connection>(page_size),
-            std::make_unique<data::Cache>(page_size, max_pages),
-        };
+        auto* adbfsm     = new Adbfsm{ page_size, max_pages };
+        auto* threadpool = util::Threadpool::get_instance();
+
+        threadpool->enqueue_detached([ctx = &adbfsm->async_ctx()] {
+            log_d({ "adbfsm: io_context running..." });
+            auto num_handlers = ctx->run();
+            log_d({ "adbfsm: io_context stopped with {} handlers executed" }, num_handlers);
+        });
+
+        return adbfsm;
     }
 
     void destroy(void* private_data)
@@ -157,7 +199,7 @@ namespace adbfsm
 
         auto ignored = util::Threadpool::terminate();
         if (ignored != 0) {
-            log_i({ "There are {} jobs waiting in Threadpool queue. Ignoring them." }, ignored);
+            log_w({ "There are {} jobs waiting in Threadpool queue. Ignoring them." }, ignored);
         }
 
         auto serial = ::getenv("ANDROID_SERIAL");
@@ -173,7 +215,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         auto maybe_stat = ok_or(path::create(path), Errc::operation_not_supported).and_then([](auto p) {
-            return get_data().tree().getattr(p);
+            return tree_blocking(&tree::FileTree::getattr, p);
         });
         if (not maybe_stat.has_value()) {
             return fuse_err(__func__, path)(maybe_stat.error());
@@ -216,7 +258,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return get_data().tree().readlink(p); })
+            .and_then([](path::Path p) { return tree_blocking(&tree::FileTree::readlink, p); })
             .and_then([&](tree::Node& node) -> Expect<void> {
                 auto target_buf = node.build_path();    // this will emits absolute path, which we don't want
                 auto target     = target_buf.as_path();
@@ -237,7 +279,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return get_data().tree().mknod(p); })
+            .and_then([](path::Path p) { return tree_blocking(&tree::FileTree::mknod, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -247,7 +289,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return get_data().tree().mkdir(p); })
+            .and_then([](path::Path p) { return tree_blocking(&tree::FileTree::mkdir, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -257,7 +299,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](auto p) { return get_data().tree().unlink(p); })
+            .and_then([](path::Path p) { return tree_blocking(&tree::FileTree::unlink, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -267,7 +309,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](auto p) { return get_data().tree().rmdir(p); })
+            .and_then([](path::Path p) { return tree_blocking(&tree::FileTree::rmdir, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -287,9 +329,7 @@ namespace adbfsm
             return fuse_err(__func__, to)(Errc::operation_not_supported);
         }
 
-        return get_data()
-            .tree()
-            .rename(*from_path, *to_path)
+        return tree_blocking(&tree::FileTree::rename, *from_path, *to_path)
             .transform_error(fuse_err(__func__, from))
             .error_or(0);
     }
@@ -299,7 +339,7 @@ namespace adbfsm
         log_i({ "{}: [size={}] {:?}" }, __func__, size, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](auto p) { return get_data().tree().truncate(p, size); })
+            .and_then([&](path::Path p) { return tree_blocking(&tree::FileTree::truncate, p, size); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -309,7 +349,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](auto p) { return get_data().tree().open(p, fi->flags); })
+            .and_then([&](path::Path p) { return tree_blocking(&tree::FileTree::open, p, fi->flags); })
             .transform([&](auto fd) { fi->fh = fd; })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
@@ -319,8 +359,8 @@ namespace adbfsm
     {
         log_i({ "{}: [offset={}|size={}] {:?}" }, __func__, offset, size, path);
 
-        auto res = ok_or(path::create(path), Errc::operation_not_supported).and_then([&](auto p) {
-            return get_data().tree().read(p, fi->fh, { buf, size }, offset);
+        auto res = ok_or(path::create(path), Errc::operation_not_supported).and_then([&](path::Path p) {
+            return tree_blocking(&tree::FileTree::read, p, fi->fh, { buf, size }, offset);
         });
         return res.has_value() ? static_cast<i32>(res.value()) : fuse_err(__func__, path)(res.error());
     }
@@ -330,7 +370,7 @@ namespace adbfsm
         log_i({ "{}: [offset={}|size={}] {:?}" }, __func__, offset, size, path);
 
         auto res = ok_or(path::create(path), Errc::operation_not_supported).and_then([&](auto p) {
-            return get_data().tree().write(p, fi->fh, { buf, size }, offset);
+            return tree_blocking(&tree::FileTree::write, p, fi->fh, { buf, size }, offset);
         });
         return res.has_value() ? static_cast<i32>(res.value()) : fuse_err(__func__, path)(res.error());
     }
@@ -340,7 +380,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](auto p) { return get_data().tree().flush(p, fi->fh); })
+            .and_then([&](path::Path p) { return tree_blocking(&tree::FileTree::flush, p, fi->fh); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -350,7 +390,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](auto p) { return get_data().tree().release(p, fi->fh); })
+            .and_then([&](path::Path p) { return tree_blocking(&tree::FileTree::release, p, fi->fh); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -369,7 +409,7 @@ namespace adbfsm
         const auto fill = [&](const char* name) { filler(buf, name, nullptr, 0, FUSE_FILL_DIR_PLUS); };
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](auto p) { return get_data().tree().readdir(p, fill); })
+            .and_then([&](path::Path p) { return tree_blocking(&tree::FileTree::readdir, p, fill); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -388,7 +428,7 @@ namespace adbfsm
         log_i({ "{}: {:?}" }, __func__, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](auto p) { return get_data().tree().utimens(p); })
+            .and_then([&](path::Path p) { return tree_blocking(&tree::FileTree::utimens, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }

--- a/source/adbfsm.cpp
+++ b/source/adbfsm.cpp
@@ -52,8 +52,8 @@ namespace
                 return 0;
             }
 
-            switch (err) {
             // filter out common errors
+            switch (err) {
             case std::errc::no_such_file_or_directory:
             case std::errc::file_exists:
             case std::errc::not_a_directory:
@@ -63,14 +63,18 @@ namespace
             case std::errc::permission_denied:
             case std::errc::read_only_file_system:
             case std::errc::filename_too_long:
-            case std::errc::invalid_argument:    //
-                return -errint;
-
-            default:
+            case std::errc::invalid_argument: {
+                if (spdlog::get_level() == spdlog::level::debug) {
+                    const auto msg = std::make_error_code(err).message();
+                    adbfsm::log_e({ "{}: {:?} returned with error code [{}]: {}" }, name, path, errint, msg);
+                }
+            } break;
+            default: {
                 const auto msg = std::make_error_code(err).message();
                 adbfsm::log_e({ "{}: {:?} returned with error code [{}]: {}" }, name, path, errint, msg);
-                return -errint;
             }
+            }
+            return -errint;
         };
     }
 }

--- a/source/data/connection.cpp
+++ b/source/data/connection.cpp
@@ -1,16 +1,20 @@
+#include "adbfsm/async/async.hpp"
 #include "adbfsm/log.hpp"
 #include "adbfsm/util/split.hpp"
 
 #include "adbfsm/data/connection.hpp"
 #include "adbfsm/path/path.hpp"
 
-#include <reproc++/drain.hpp>
-#include <reproc++/reproc.hpp>
+#define BOOST_PROCESS_VERSION 2
+#include <boost/process.hpp>
+#include <boost/process/extend.hpp>
 
 #include <grp.h>
 #include <pwd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+namespace bp = boost::process::v2;
 
 namespace
 {
@@ -90,121 +94,53 @@ namespace
         return Error::Unknown;
     }
 
-    adbfsm::Expect<adbfsm::String> exec(adbfsm::Span<const adbfsm::Str> cmd, bool check = true)
-    {
-        // adbfsm::log_d({ "exec command: {::?}" }, cmd);    // quite heavy to log :D
-
-        using Sink = reproc::sink::string;
-        using namespace std::chrono_literals;
-
-        auto proc = reproc::process{};
-        auto args = reproc::arguments{ cmd };
-        auto opts = reproc::options{};
-
-        opts.redirect.err.type = reproc::redirect::pipe;
-
-        auto out = adbfsm::String{};
-        auto err = adbfsm::String{};
-
-        auto ec             = proc.start(args, opts);
-        auto ec_drain       = reproc::drain(proc, Sink{ out }, Sink{ err });
-        auto [ret, ec_wait] = proc.wait(10s);
-
-        if (ec) {
-            adbfsm::log_e({ "failed to start command {}: {}" }, cmd, ec.message());
-            return adbfsm::Unexpect{ adbfsm::Errc::protocol_error };
-        }
-        if (ec_wait) {
-            adbfsm::log_e({ "failed to execute command {}: {}" }, cmd, ec_wait.message());
-            return adbfsm::Unexpect{ adbfsm::Errc::timed_out };
-        }
-        if (ec_drain) {
-            adbfsm::log_e({ "failed to drain command output {}: {}" }, cmd, ec_drain.message());
-            return adbfsm::Unexpect{ static_cast<adbfsm::Errc>(ec_drain.value()) };
-        }
-
-        if (check and ret != 0) {
-            auto errmsg = not err.empty() ? adbfsm::util::strip(err) : adbfsm::util::strip(out);
-            adbfsm::log_w({ "non-zero command status ({}) {}: err: [{}]" }, ret, cmd, errmsg);
-            return adbfsm::Unexpect{ to_errc(parse_stderr(errmsg)) };
-        }
-        return std::move(out);
-    }
-
-    /**
-     * @brief Execute a command and call the output function with the output.
-     *
-     * @param cmd The command to execute.
-     * @param in The input to the command (stdin).
-     * @param outfn Output function to call with the output.
-     *
-     * @return The number of bytes written to the command's stdin.
-     */
-    template <std::invocable<adbfsm::Span<const adbfsm::u8>> Out>
-    adbfsm::Expect<adbfsm::usize> exec_fn(
-        adbfsm::Span<const adbfsm::Str> cmd,
-        adbfsm::Span<const char>        in,
-        Out                             outfn
+    adbfsm::async::Await<adbfsm::Expect<adbfsm::String>> exec_async(
+        adbfsm::Str                     exe,
+        adbfsm::Span<const adbfsm::Str> args,
+        adbfsm::Str                     in,
+        bool                            check
     )
     {
-        // adbfsm::log_d({ "exec command: {::?}" }, cmd);    // quite heavy to log :D
+        namespace async = adbfsm::async;
 
-        using namespace std::chrono_literals;
+        auto exec = co_await async::this_coro::executor;
 
-        auto proc = reproc::process{};
-        auto args = reproc::arguments{ cmd };
-        auto opts = reproc::options{};
+        auto pipe_in  = async::pipe::Write{ exec };
+        auto pipe_out = async::pipe::Read{ exec };
+        auto pipe_err = async::pipe::Read{ exec };
 
-        opts.redirect.err.type = reproc::redirect::pipe;
-        if (not in.empty()) {
-            opts.redirect.in.type = reproc::redirect::pipe;
-        }
-
-        auto ec       = proc.start(args, opts);
-        auto write_in = 0uz;
-
-        if (not in.empty()) {
-            auto [write, ec_in] = proc.write(reinterpret_cast<const adbfsm::u8*>(in.data()), in.size());
-            if (ec_in) {
-                adbfsm::log_e({ "failed to write command input {}: {}" }, cmd, ec_in.message());
-                return adbfsm::Unexpect{ adbfsm::Errc::protocol_error };
-            }
-            if (ec_in = proc.close(reproc::stream::in); ec_in) {
-                adbfsm::log_e({ "failed to close command input {}: {}" }, cmd, ec_in.message());
-                return adbfsm::Unexpect{ adbfsm::Errc::protocol_error };
-            }
-            write_in = write;
-        }
-
-        auto err = adbfsm::String{};
-        auto out = [&](reproc::stream, const adbfsm::u8* buffer, adbfsm::usize size) {
-            outfn(adbfsm::Span{ buffer, size });
-            return std::error_code{};
+        auto proc = bp::process{
+            exec,
+            bp::environment::find_executable(exe),
+            args,
+            bp::process_stdio{ pipe_in, pipe_out, pipe_err },
         };
 
-        auto ec_drain       = reproc::drain(proc, out, reproc::sink::string{ err });
-        auto [ret, ec_wait] = proc.wait(10s);
-
-        if (ec) {
-            adbfsm::log_e({ "failed to start command {}: {}" }, cmd, ec.message());
-            return adbfsm::Unexpect{ adbfsm::Errc::protocol_error };
-        }
-        if (ec_wait) {
-            adbfsm::log_e({ "failed to execute command {}: {}" }, cmd, ec_wait.message());
-            return adbfsm::Unexpect{ adbfsm::Errc::timed_out };
-        }
-        if (ec_drain) {
-            adbfsm::log_e({ "failed to drain command output {}: {}" }, cmd, ec_drain.message());
-            return adbfsm::Unexpect{ static_cast<adbfsm::Errc>(ec_drain.value()) };
+        if (auto [ec, _] = co_await async::write_all(pipe_in, in); ec) {
+            adbfsm::log_e({ "{}: failed to read to stdin: {}" }, __func__, ec.message());
+            co_return async::to_generic_err(ec);
         }
 
-        if (ret != 0) {
-            auto errmsg = adbfsm::util::strip(err);
-            adbfsm::log_w({ "non-zero command status ({}) {}: err: [{}]" }, ret, cmd, errmsg);
-            return adbfsm::Unexpect{ to_errc(parse_stderr(err)) };
+        auto out = std::string{};
+        if (auto [ec, _] = co_await async::read_all(pipe_out, out); ec) {
+            adbfsm::log_e({ "{}: failed to read from stdout: {}" }, __func__, ec.message());
+            co_return async::to_generic_err(ec);
         }
 
-        return write_in;
+        auto err = std::string{};
+        if (auto [ec, _] = co_await async::read_all(pipe_err, err); ec) {
+            adbfsm::log_e({ "{}: failed to read from stderr: {}" }, __func__, ec.message());
+            co_return async::to_generic_err(ec);
+        }
+
+        auto ret = co_await proc.async_wait();
+        if (check and ret != 0) {
+            auto errmsg = not err.empty() ? adbfsm::util::strip(err) : adbfsm::util::strip(out);
+            adbfsm::log_w({ "non-zero command status ({}) {} {}: err: [{}]" }, ret, exe, args, errmsg);
+            co_return adbfsm::Unexpect{ to_errc(parse_stderr(errmsg)) };
+        }
+
+        co_return std::move(out);
     }
 
     template <typename T>
@@ -297,18 +233,19 @@ namespace adbfsm::data
 {
     using namespace std::string_view_literals;
 
-    Expect<Gen<ParsedStat>> Connection::statdir(path::Path path)
+    Connection::Aresult<Gen<ParsedStat>> Connection::statdir(path::Path path)
     {
         const auto qpath = quoted(path);
-        const auto cmd   = Array{
-            "adb"sv, "shell"sv, "find"sv, Str{ qpath }, "-maxdepth"sv,
-            "1"sv,   "-exec"sv, "stat"sv, "-c"sv,       "'%f %h %s %u %g %X %Y %Z %n'"sv,
-            "{}"sv,  "+"sv,
+        const auto args  = Array{
+            "shell"sv,     "find"sv, Str{ qpath },
+            "-maxdepth"sv, "1"sv,    "-exec"sv,
+            "stat"sv,      "-c"sv,   "'%f %h %s %u %g %X %Y %Z %n'"sv,
+            "{}"sv,        "+"sv,
         };
 
-        auto out = exec(cmd, false);
+        auto out = co_await exec_async("adb", args, "", false);
         if (not out.has_value()) {
-            return Unexpect{ out.error() };
+            co_return Unexpect{ out.error() };
         }
 
         auto generator = [](String out) -> Gen<ParsedStat> {
@@ -323,17 +260,17 @@ namespace adbfsm::data
             }
         };
 
-        return generator(std::move(*out));
+        co_return generator(std::move(*out));
     }
 
-    Expect<Stat> Connection::stat(path::Path path)
+    Connection::Aresult<Stat> Connection::stat(path::Path path)
     {
         const auto qpath = quoted(path);
-        const auto cmd   = Array{
-            "adb"sv, "shell"sv, "stat"sv, "-c"sv, "'%f %h %s %u %g %X %Y %Z %n'"sv, Str{ qpath },
-        };
+        const auto cmd = Array{ "shell"sv, "stat"sv, "-c"sv, "'%f %h %s %u %g %X %Y %Z %n'"sv, Str{ qpath } };
 
-        return exec(cmd).and_then([&](String out) {
+        auto res = co_await exec_async("adb", cmd, "", true);
+
+        co_return res.and_then([&](Str out) {
             return ok_or(parse_file_stat(util::strip(out)), Errc::io_error)
                 .transform([](ParsedStat parsed) { return parsed.stat; })
                 .transform_error([&](auto err) {
@@ -343,71 +280,74 @@ namespace adbfsm::data
         });
     }
 
-    Expect<path::PathBuf> Connection::readlink(path::Path path)
+    Connection::Aresult<path::PathBuf> Connection::readlink(path::Path path)
     {
         const auto qpath = quoted(path);
-        const auto cmd   = Array{ "adb"sv, "shell"sv, "readlink"sv, Str{ qpath } };
-        return exec(cmd).transform([&](String target) {
+        const auto args  = Array{ "shell"sv, "readlink"sv, Str{ qpath } };
+
+        auto res = co_await exec_async("adb", args, "", true);
+
+        co_return res.transform([&](Str target) {
             auto target_path = resolve_path(path.parent_path(), util::strip(target));
             return path::create_buf(std::move(target_path)).value();
         });
     }
 
-    Expect<void> Connection::touch(path::Path path, bool create)
+    Connection::Aresult<void> Connection::touch(path::Path path, bool create)
     {
         const auto qpath = quoted(path);
         if (create) {
-            const auto cmd = Array{ "adb"sv, "shell"sv, "touch"sv, Str{ qpath } };
-            return exec(cmd).transform(sink_void);
+            const auto args = Array{ "shell"sv, "touch"sv, Str{ qpath } };
+            co_return (co_await exec_async("adb", args, "", true)).transform(sink_void);
         } else {
-            const auto cmd = Array{ "adb"sv, "shell"sv, "touch"sv, "-c"sv, Str{ qpath } };
-            return exec(cmd).transform(sink_void);
+            const auto args = Array{ "shell"sv, "touch"sv, "-c"sv, Str{ qpath } };
+            co_return (co_await exec_async("adb", args, "", true)).transform(sink_void);
         }
     }
 
-    Expect<void> Connection::mkdir(path::Path path)
+    Connection::Aresult<void> Connection::mkdir(path::Path path)
     {
         const auto qpath = quoted(path);
-        const auto cmd   = Array{ "adb"sv, "shell"sv, "mkdir"sv, Str{ qpath } };
-        return exec(cmd).transform(sink_void);
+        const auto args  = Array{ "shell"sv, "mkdir"sv, Str{ qpath } };
+        co_return (co_await exec_async("adb", args, "", true)).transform(sink_void);
     }
 
-    Expect<void> Connection::rm(path::Path path, bool recursive)
+    Connection::Aresult<void> Connection::rm(path::Path path, bool recursive)
     {
         const auto qpath = quoted(path);
         if (not recursive) {
-            const auto cmd = Array{ "adb"sv, "shell"sv, "rm"sv, Str{ qpath } };
-            return exec(cmd).transform(sink_void);
+            const auto args = Array{ "shell"sv, "rm"sv, Str{ qpath } };
+            co_return (co_await exec_async("adb", args, "", true)).transform(sink_void);
         } else {
-            const auto cmd = Array{ "adb"sv, "shell"sv, "rm"sv, "-r"sv, Str{ qpath } };
-            return exec(cmd).transform(sink_void);
+            const auto args = Array{ "shell"sv, "rm"sv, "-r"sv, Str{ qpath } };
+            co_return (co_await exec_async("adb", args, "", true)).transform(sink_void);
         }
     }
 
-    Expect<void> Connection::rmdir(path::Path path)
+    Connection::Aresult<void> Connection::rmdir(path::Path path)
     {
         const auto qpath = quoted(path);
-        const auto cmd   = Array{ "adb"sv, "shell"sv, "rmdir"sv, Str{ qpath } };
-        return exec(cmd).transform(sink_void);
+        const auto args  = Array{ "shell"sv, "rmdir"sv, Str{ qpath } };
+        co_return (co_await exec_async("adb", args, "", true)).transform(sink_void);
     }
 
-    Expect<void> Connection::mv(path::Path from, path::Path to)
+    Connection::Aresult<void> Connection::mv(path::Path from, path::Path to)
     {
         const auto qfrom = quoted(from);
         const auto qto   = quoted(to);
-        const auto cmd   = Array{ "adb"sv, "shell"sv, "mv"sv, Str{ qfrom }, Str{ qto } };
-        return exec(cmd).transform(sink_void);
+        const auto args  = Array{ "shell"sv, "mv"sv, Str{ qfrom }, Str{ qto } };
+        co_return (co_await exec_async("adb", args, "", true)).transform(sink_void);
     }
 
-    Expect<void> Connection::truncate(path::Path path, off_t size)
+    Connection::Aresult<void> Connection::truncate(path::Path path, off_t size)
     {
         const auto qpath = quoted(path);
         const auto sizes = fmt::format("{}", size);
-        const auto cmd   = Array{ "adb"sv, "shell"sv, "truncate"sv, "-s"sv, Str{ sizes }, Str{ qpath } };
-        return exec(cmd).transform(sink_void);
+        const auto args  = Array{ "shell"sv, "truncate"sv, "-s"sv, Str{ sizes }, Str{ qpath } };
+        co_return (co_await exec_async("adb", args, "", true)).transform(sink_void);
     }
 
-    Expect<u64> Connection::open(path::Path /* path */, int /* flags */)
+    Connection::Aresult<u64> Connection::open(path::Path /* path */, int /* flags */)
     {
         /*
          * Since we're using a streaming approach to read/write files, there is no need to do open or
@@ -417,18 +357,17 @@ namespace adbfsm::data
          * Thus, there is really no need to do anything here.
          */
 
-        return m_counter.fetch_add(1, std::memory_order::relaxed) + 1;
+        co_return m_counter.fetch_add(1, std::memory_order::relaxed) + 1;
     }
 
-    Expect<usize> Connection::read(path::Path path, Span<char> out, off_t offset)
+    Connection::Aresult<usize> Connection::read(path::Path path, Span<char> out, off_t offset)
     {
         const auto skip  = fmt::format("skip={}", offset);
         const auto count = fmt::format("count={}", out.size());
         const auto iff   = fmt::format("if=\"{}\"", path.fullpath());
         const auto bs    = fmt::format("bs={}", m_page_size);
 
-        const auto cmd = Array{
-            "adb"sv,
+        const auto args = Array{
             "shell"sv,
             "dd"sv,
             "iflag=skip_bytes,count_bytes"sv,    // https://stackoverflow.com/a/40792605/16506263
@@ -438,26 +377,19 @@ namespace adbfsm::data
             Str{ iff },
         };
 
-        auto read_count = 0uz;
-        auto outfn      = [&](Span<const u8> data) {
-            auto remaining = out.size() - read_count;
-            auto to_copy   = std::min(data.size(), remaining);
-
-            std::copy_n(data.data(), to_copy, out.data() + read_count);
-            read_count += to_copy;
-        };
-
-        return exec_fn(cmd, "", outfn).transform([&](usize) { return read_count; });
+        co_return (co_await exec_async("adb", args, "", true)).transform([&](String str) {
+            std::copy_n(str.data(), str.size(), str.data());
+            return str.size();
+        });
     }
 
-    Expect<usize> Connection::write(path::Path path, Span<const char> in, off_t offset)
+    Connection::Aresult<usize> Connection::write(path::Path path, Span<const char> in, off_t offset)
     {
         const auto seek = fmt::format("seek={}", offset);
         const auto off  = fmt::format("of=\"{}\"", path.fullpath());
         const auto bs   = fmt::format("bs={}", m_page_size);
 
-        const auto cmd = Array{
-            "adb"sv,
+        const auto args = Array{
             "shell"sv,
             "dd"sv,
             "oflag=seek_bytes"sv,    // same as above, though I don't know if this is really needed
@@ -467,10 +399,13 @@ namespace adbfsm::data
             Str{ off },
         };
 
-        return exec_fn(cmd, in, [&](Span<const u8>) { /* ignore */ });
+        auto in_str = Str{ in.data(), in.size() };
+        co_return (co_await exec_async("adb", args, in_str, true)).transform([&](auto&&) {
+            return in_str.size();    // assume all the data is written to device
+        });
     }
 
-    Expect<void> Connection::flush(path::Path /* path */)
+    Connection::Aresult<void> Connection::flush(path::Path /* path */)
     {
         /*
          * The streaming approach is immediate, so there is no need to flush the file. At least for the
@@ -480,7 +415,7 @@ namespace adbfsm::data
         return {};
     }
 
-    Expect<void> Connection::release(path::Path /* path */)
+    Connection::Aresult<void> Connection::release(path::Path /* path */)
     {
         /*
          * The reason this part is a no-op is the same as the open function. We don't need to do any
@@ -490,19 +425,19 @@ namespace adbfsm::data
         return {};
     }
 
-    Expect<void> start_connection()
+    Connection::Aresult<void> start_connection()
     {
-        const auto cmd = Array{ "adb"sv, "start-server"sv };
-        return exec(cmd).transform(sink_void);
+        const auto args = Array{ "start-server"sv };
+        co_return (co_await exec_async("adb", args, "", true)).transform(sink_void);
     }
 
-    Expect<Vec<Device>> list_devices()
+    Connection::Aresult<Vec<Device>> list_devices()
     {
-        const auto cmd = Array{ "adb"sv, "devices"sv };
-        auto       out = exec(cmd);
+        const auto args = Array{ "devices"sv };
+        auto       out  = co_await exec_async("adb", args, "", true);
 
         if (not out.has_value()) {
-            return Unexpect{ out.error() };
+            co_return Unexpect{ out.error() };
         }
 
         auto devices = Vec<Device>{};
@@ -531,6 +466,6 @@ namespace adbfsm::data
             devices.emplace_back(String{ *serial_str }, status);
         }
 
-        return devices;
+        co_return devices;
     }
 }

--- a/source/data/connection.cpp
+++ b/source/data/connection.cpp
@@ -156,8 +156,6 @@ namespace
             co_return adbfsm::Unexpect{ async::to_generic_err(ec) };
         }
 
-        adbfsm::log_d({ "{}: drained stdout: {:?}" }, __func__, out);
-
         auto err = std::string{};
         if (auto ec = co_await drain_pipe(pipe_err, err); ec and ec != boost::asio::error::eof) {
             adbfsm::log_e({ "{}: failed to read from stderr: {}" }, __func__, ec.message());


### PR DESCRIPTION
The asynchronous code is possible by these libraries
- `Boost.Asio`: the main asynchronous runtime
- `Boost.Process`: async process handling used to spawn `adb shell` commands
- `saf`: scheduler-aware future/promise to synchronize access to shared resource (cache)

The interfacing between the async world to sync world of `FUSE` is done at the binding employing `std::future` to block FUSE workers while not interfering with async operations.