### PR TITLE
Add logcat operation through IPC

### DIFF
--- a/madbfs-common/include/madbfs-common/async/async.hpp
+++ b/madbfs-common/include/madbfs-common/async/async.hpp
@@ -143,6 +143,18 @@ namespace madbfs::async
         co_return res;
     }
 
+    template <typename... Ts>
+    Await<Tup<ToUnit<Ts>...>> wait_all(Await<Ts>&&... awaitables) noexcept(false)
+    {
+        using net::experimental::awaitable_operators::operator&&;
+        if constexpr ((std::same_as<Ts, void> and ...)) {
+            co_await (std::move(awaitables) && ...);
+            co_return Tup<ToUnit<Ts>...>{};
+        } else {
+            co_return co_await (std::move(awaitables) && ...);
+        }
+    }
+
     template <typename T>
     Await<Opt<ToUnit<T>>> timeout(
         Await<T>&&            awaitable,

--- a/madbfs-common/include/madbfs-common/util/var_wrapper.hpp
+++ b/madbfs-common/include/madbfs-common/util/var_wrapper.hpp
@@ -85,5 +85,18 @@ namespace madbfs::util
             using Var = detail::CopyCVRef<Self, Var>;
             return static_cast<Var>(self);
         }
+
+        template <typename T>
+        bool holds()
+        {
+            return std::holds_alternative<T>(as_var());
+        }
+
+        template <typename T>
+        T* as()
+        {
+            auto& var = as_var();
+            return std::get_if<T>(&var);
+        }
     };
 }

--- a/madbfs-msg/src/main.cpp
+++ b/madbfs-msg/src/main.cpp
@@ -274,7 +274,7 @@ int send_message(std::span<const std::string> message, fs::path socket_path)
         if (value_str) {
             return too_much(op_str, 0);
         }
-        op = ipc::op::Logcat{};
+        op = ipc::op::Logcat{ .color = ::isatty(::fileno(stdout)) != 0 };
     } else if (op_str == ipc::op::names::info) {
         if (value_str) {
             return too_much(op_str, 0);
@@ -364,8 +364,8 @@ int send_message(std::span<const std::string> message, fs::path socket_path)
             sig_set.cancel();
             co_return 0;
         },
-        [&](this auto, ipc::op::Logcat) -> madbfs::Await<int> {
-            auto response = co_await client->logcat();
+        [&](this auto, ipc::op::Logcat op) -> madbfs::Await<int> {
+            auto response = co_await client->logcat(op);
             if (not response) {
                 auto msg = std::make_error_code(response.error()).message();
                 fmt::println(stderr, "error: failed to send message: {}", msg);

--- a/madbfs-msg/src/main.cpp
+++ b/madbfs-msg/src/main.cpp
@@ -1,6 +1,7 @@
 #include <madbfs-common/async/async.hpp>
 #include <madbfs-common/ipc.hpp>
 #include <madbfs-common/log.hpp>
+#include <madbfs-common/util/overload.hpp>
 
 #include <boost/json.hpp>
 #include <boost/program_options.hpp>
@@ -269,6 +270,11 @@ int send_message(std::span<const std::string> message, fs::path socket_path)
             return too_much(op_str, 0);
         }
         op = ipc::op::Help{};
+    } else if (op_str == ipc::op::names::logcat) {
+        if (value_str) {
+            return too_much(op_str, 0);
+        }
+        op = ipc::op::Logcat{};
     } else if (op_str == ipc::op::names::info) {
         if (value_str) {
             return too_much(op_str, 0);
@@ -328,17 +334,68 @@ int send_message(std::span<const std::string> message, fs::path socket_path)
         return 1;
     }
 
-    auto fut = async::spawn(context, client->send(*op), async::use_future);
+    auto sig_set = madbfs::net::signal_set{ context, SIGINT, SIGTERM };
+    sig_set.async_wait([&](auto, auto) { client->stop(); });
+
+    auto coro = op->visit(madbfs::util::Overload{
+        [&](this auto, ipc::FsOp op) -> madbfs::Await<int> {
+            auto response = co_await client->send(op);
+            if (not response) {
+                auto msg = std::make_error_code(response.error()).message();
+                fmt::println(stderr, "error: failed to send message: {}", msg);
+                co_return 1;
+            }
+
+            pretty_print(*response);
+
+            sig_set.cancel();
+            co_return 0;
+        },
+        [&](this auto, ipc::op::Help) -> madbfs::Await<int> {
+            auto response = co_await client->help();
+            if (not response) {
+                auto msg = std::make_error_code(response.error()).message();
+                fmt::println(stderr, "error: failed to send message: {}", msg);
+                co_return 1;
+            }
+
+            pretty_print(*response);
+
+            sig_set.cancel();
+            co_return 0;
+        },
+        [&](this auto, ipc::op::Logcat) -> madbfs::Await<int> {
+            auto response = co_await client->logcat();
+            if (not response) {
+                auto msg = std::make_error_code(response.error()).message();
+                fmt::println(stderr, "error: failed to send message: {}", msg);
+                co_return 1;
+            }
+
+            fmt::println("{:-^80}", "[ LOGCAT START ]");
+
+            for (auto awaitable : *response) {
+                auto message = co_await std::move(awaitable);
+                if (not message) {
+                    break;
+                }
+
+                // the newline is already in the message :P
+                fmt::print("{}", *message);
+            }
+
+            fmt::println("{:-^80}", "[ LOGCAT END ]");
+
+            sig_set.cancel();
+            co_return 0;
+        },
+    });
+
+    auto fut = async::spawn(context, std::move(coro), async::use_future);
+
     context.run();
 
-    if (auto response = fut.get(); not response) {
-        auto msg = std::make_error_code(response.error()).message();
-        fmt::println(stderr, "error: failed to send message: {}", msg);
-        return 1;
-    } else {
-        pretty_print(*response);
-        return 0;
-    }
+    return fut.get();
 }
 
 int main(int argc, char** argv)

--- a/madbfs/include/madbfs/args.hpp
+++ b/madbfs/include/madbfs/args.hpp
@@ -412,13 +412,18 @@ namespace madbfs::args
             server = std::filesystem::absolute(madbfs_opt.server);
         }
 
+        // if logfile is set to stdout but not in foreground mode, ignore it.
+        auto log_file = std::strcmp(madbfs_opt.log_file, "-") == 0 and not opts.foreground
+                          ? ""
+                          : madbfs_opt.log_file;
+
         co_return ParseResult::Opt{
             .opt = {
                 .mount     = std::move(mountpoint),
                 .serial    = madbfs_opt.serial,
                 .server    = server,
                 .log_level = log_level.value(),
-                .log_file  = madbfs_opt.log_file,
+                .log_file  = log_file,
                 .cachesize = std::bit_ceil(std::max(static_cast<usize>(madbfs_opt.cache_size), 128uz)),
                 .pagesize  = std::bit_ceil(std::max(static_cast<usize>(madbfs_opt.page_size), 64uz)),
                 .ttl       = madbfs_opt.ttl,

--- a/madbfs/include/madbfs/madbfs.hpp
+++ b/madbfs/include/madbfs/madbfs.hpp
@@ -83,7 +83,7 @@ namespace madbfs
          *
          * This function handles all requested operations from peers that comes from `m_ipc` instance.
          */
-        Await<boost::json::value> ipc_handler(ipc::Op op);
+        Await<boost::json::value> ipc_handler(ipc::FsOp op);
 
         async::Context   m_async_ctx;
         async::WorkGuard m_work_guard;    // to prevent `async::Context` from returning immediately

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -92,7 +92,7 @@ namespace madbfs
         , m_mountpoint{ mountpoint }
     {
         if (m_ipc) {
-            auto coro = m_ipc->launch([this](ipc::Op op) { return ipc_handler(op); });
+            auto coro = m_ipc->launch([this](ipc::FsOp op) { return ipc_handler(op); });
             async::spawn(m_async_ctx, std::move(coro), [](std::exception_ptr e) {
                 log::log_exception(e, "Madbfs");
             });
@@ -112,7 +112,7 @@ namespace madbfs
         m_work_thread.join();
     }
 
-    Await<boost::json::value> Madbfs::ipc_handler(ipc::Op op)
+    Await<boost::json::value> Madbfs::ipc_handler(ipc::FsOp op)
     {
         namespace json = boost::json;
 
@@ -121,19 +121,6 @@ namespace madbfs
         constexpr usize lowest_max_pages  = 128;
 
         auto overload = util::Overload{
-            [&](ipc::op::Help) -> Await<json::value> {
-                co_return json::value{
-                    { "operations",
-                      {
-                          ipc::op::names::help,
-                          ipc::op::names::info,
-                          ipc::op::names::invalidate_cache,
-                          ipc::op::names::set_page_size,
-                          ipc::op::names::set_cache_size,
-                          ipc::op::names::set_ttl,
-                      } },
-                };
-            },
             [&](ipc::op::Info) -> Await<json::value> {
                 auto page_size     = m_cache.page_size();
                 auto max_pages     = m_cache.max_pages();

--- a/madbfs/src/main.cpp
+++ b/madbfs/src/main.cpp
@@ -77,13 +77,15 @@ int main(int argc, char** argv)
     fmt::println("[madbfs] unmount with 'fusermount -u {:?}'", opt.mount);
 
     madbfs::log::init(opt.log_level, opt.log_file);
-    madbfs::log_i(
-        "[madbfs] mount '{}' at '{}' with cache size {} MiB and page size {} KiB",
-        opt.serial,
-        opt.mount,
-        opt.cachesize,
-        opt.pagesize
-    );
+    if (opt.log_file != "-") {
+        madbfs::log_i(
+            "[madbfs] mount '{}' at '{}' with cache size {} MiB and page size {} KiB",
+            opt.serial,
+            opt.mount,
+            opt.cachesize,
+            opt.pagesize
+        );
+    }
 
     if (::setenv("ANDROID_SERIAL", opt.serial.c_str(), 1) < 0) {
         fmt::println(stderr, "error: failed to set env variable 'ANDROID_SERIAL' ({})", strerror(errno));


### PR DESCRIPTION
It's not uncommon to want to see the log of a running `madbfs` instance (not in foreground) while developing for debugging purposes. This feature enables that.