### PR TITLE
Streamline read write

### DIFF
--- a/madbfs/CMakeLists.txt
+++ b/madbfs/CMakeLists.txt
@@ -11,9 +11,9 @@ target_sources(
   PRIVATE
     src/adb.cpp
     src/args.cpp
+    src/cache.cpp
     src/cmd.cpp
     src/connection.cpp
-    src/data/cache.cpp
     src/file_handle_store.cpp
     src/filesystem.cpp
     src/madbfs.cpp

--- a/madbfs/CMakeLists.txt
+++ b/madbfs/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
     src/cmd.cpp
     src/connection.cpp
     src/data/cache.cpp
+    src/file_handle_store.cpp
     src/filesystem.cpp
     src/madbfs.cpp
     src/node.cpp

--- a/madbfs/CMakeLists.txt
+++ b/madbfs/CMakeLists.txt
@@ -9,19 +9,18 @@ add_library(madbfs-lib STATIC)
 target_sources(
   madbfs-lib
   PRIVATE
-    src/madbfs.cpp
-    src/args.cpp
     src/adb.cpp
+    src/args.cpp
     src/cmd.cpp
+    src/connection.cpp
+    src/data/cache.cpp
+    src/filesystem.cpp
+    src/madbfs.cpp
+    src/node.cpp
     src/operations.cpp
     src/path.cpp
-    src/connection.cpp
     src/transport/adb_transport.cpp
     src/transport/proxy_transport.cpp
-    src/data/cache.cpp
-    src/tree/file_tree.cpp
-    src/tree/node.cpp
-    src/tree/node.cpp
 )
 target_link_libraries(
   madbfs-lib

--- a/madbfs/include/madbfs/cache.hpp
+++ b/madbfs/include/madbfs/cache.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "madbfs/data/stat.hpp"
 #include "madbfs/path.hpp"
+#include "madbfs/stat.hpp"
 
 #include <madbfs-common/async/async.hpp>
 
 #include <saf.hpp>
 
-#include <cassert>
 #include <list>
 #include <map>
 #include <unordered_map>
@@ -17,7 +16,7 @@ namespace madbfs
     class Connection;
 }
 
-namespace madbfs::data
+namespace madbfs
 {
     /**
      * @class PageKey
@@ -135,7 +134,7 @@ namespace madbfs::data
          * and the mode can upgraded from O_RDONLY or O_WRONLY to O_RDRW the file will be closed then reopened
          * with the O_RDRW mode.
          */
-        AExpect<void> hint_open(Id id, path::Path path, data::OpenMode mode);
+        AExpect<void> hint_open(Id id, path::Path path, OpenMode mode);
 
         /**
          * @brief Close the associated fd to real file for this node.
@@ -144,7 +143,7 @@ namespace madbfs::data
          *
          * Unlike `hint_open()` this function will immediately close the file descriptor to the real file.
          */
-        AExpect<void> hint_close(Id id, data::OpenMode mode);
+        AExpect<void> hint_close(Id id, OpenMode mode);
 
         /**
          * @brief Read bytes from file with desired id at an offset into buffer.

--- a/madbfs/include/madbfs/connection.hpp
+++ b/madbfs/include/madbfs/connection.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "madbfs/data/stat.hpp"
 #include "madbfs/path.hpp"
+#include "madbfs/stat.hpp"
 #include "madbfs/transport/transport.hpp"
 
 #include <madbfs-common/async/async.hpp>
@@ -27,8 +27,8 @@ namespace madbfs
      */
     struct ParsedStat
     {
-        data::Stat stat;
-        Str        name;
+        Stat stat;
+        Str  name;
     };
 
     namespace connection_strategy
@@ -177,7 +177,7 @@ namespace madbfs
          *
          * @return The stat of the file or directory.
          */
-        AExpect<data::Stat> stat(path::Path path);
+        AExpect<Stat> stat(path::Path path);
 
         /**
          * @brief Get the real file pointed by a symlink.
@@ -271,7 +271,7 @@ namespace madbfs
          * @param path Path to the file on the device.
          * @param mode Mode in which the file will be opened.
          */
-        AExpect<u64> open(path::Path path, data::OpenMode mode);
+        AExpect<u64> open(path::Path path, OpenMode mode);
 
         /**
          * @brief Close a file descriptor.

--- a/madbfs/include/madbfs/data/stat.hpp
+++ b/madbfs/include/madbfs/data/stat.hpp
@@ -6,7 +6,7 @@
 
 #include <atomic>
 
-namespace madbfs::tree
+namespace madbfs
 {
     class Node;
 }
@@ -21,7 +21,7 @@ namespace madbfs::data
     class Id
     {
     public:
-        friend ::madbfs::tree::Node;
+        friend ::madbfs::Node;
 
         Id() = default;
         u64 inner() const { return m_inner; }

--- a/madbfs/include/madbfs/file_handle_store.hpp
+++ b/madbfs/include/madbfs/file_handle_store.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "madbfs/data/stat.hpp"
+
+namespace madbfs
+{
+    class Node;
+}
+
+namespace madbfs
+{
+    struct FileHandle
+    {
+        Node*          node;
+        data::OpenMode mode;
+    };
+
+    class FileHandleStore
+    {
+    public:
+        /**
+         * @brief Get file handle from file handle store for file descriptor.
+         *
+         * @param fd File descriptor.
+         *
+         * @return FileHandle if exists, else default initialized FileHandle.
+         *
+         * The complexity of the operation is constant.
+         */
+        FileHandle find(u64 fd);
+
+        /**
+         * @brief Get associated `Node` from file handle store for file descriptor with specified open mode.
+         *
+         * @param fd File descriptor.
+         * @param mode Open file mode.
+         *
+         * @return The node if found and fulfill the mode else `Errc::bad_file_descriptor`.
+         *
+         * The complexity of the operation is constant.
+         */
+        Node* find(u64 fd, data::OpenMode mode);
+
+        /**
+         * @brief Store `Node` pointer into file handle store.
+         *
+         * @param node The node to be inserted.
+         * @param mode Open file mode for the node.
+         *
+         * @return File descriptor (position of the node in the store).
+         *
+         * The complexity of the opration is linear (depends on number of handles before finding a hole).
+         */
+        u64 store(Node* node, data::OpenMode mode);
+
+        /**
+         * @brief Release the associated node of file descriptor from the file handle store.
+         *
+         * @param fd File descriptor.
+         *
+         * @return The released node if exists, else default initialized FileHandle.
+         *
+         * The complexity of the operation is constant.
+         */
+        FileHandle release(u64 fd);
+
+        FRange auto iter() { return sv::zip(m_nodes, m_modes); }
+        FRange auto iter() const { return sv::zip(std::as_const(m_nodes), std::as_const(m_modes)); }
+
+        usize size() const { return m_nodes.size(); }
+
+    private:
+        std::vector<Node*>          m_nodes;
+        std::vector<data::OpenMode> m_modes;
+    };
+}

--- a/madbfs/include/madbfs/file_handle_store.hpp
+++ b/madbfs/include/madbfs/file_handle_store.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "madbfs/data/stat.hpp"
+#include "madbfs/stat.hpp"
 
 namespace madbfs
 {
@@ -11,8 +11,8 @@ namespace madbfs
 {
     struct FileHandle
     {
-        Node*          node;
-        data::OpenMode mode;
+        Node*    node;
+        OpenMode mode;
     };
 
     class FileHandleStore
@@ -39,7 +39,7 @@ namespace madbfs
          *
          * The complexity of the operation is constant.
          */
-        Node* find(u64 fd, data::OpenMode mode);
+        Node* find(u64 fd, OpenMode mode);
 
         /**
          * @brief Store `Node` pointer into file handle store.
@@ -51,7 +51,7 @@ namespace madbfs
          *
          * The complexity of the opration is linear (depends on number of handles before finding a hole).
          */
-        u64 store(Node* node, data::OpenMode mode);
+        u64 store(Node* node, OpenMode mode);
 
         /**
          * @brief Release the associated node of file descriptor from the file handle store.
@@ -70,7 +70,7 @@ namespace madbfs
         usize size() const { return m_nodes.size(); }
 
     private:
-        std::vector<Node*>          m_nodes;
-        std::vector<data::OpenMode> m_modes;
+        std::vector<Node*>    m_nodes;
+        std::vector<OpenMode> m_modes;
     };
 }

--- a/madbfs/include/madbfs/file_handle_store.hpp
+++ b/madbfs/include/madbfs/file_handle_store.hpp
@@ -15,6 +15,15 @@ namespace madbfs
         OpenMode mode;
     };
 
+    /**
+     * @class FileHandleStore
+     *
+     * @brief Storage for open file handles.
+     *
+     * The lifetime of the nodes pointed to by this store should be at the very least from `store()` to
+     * `release()`. If you can't guarantee that the node pointed to can't live til `release()`, `erase()`
+     * them.
+     */
     class FileHandleStore
     {
     public:
@@ -63,6 +72,17 @@ namespace madbfs
          * The complexity of the operation is constant.
          */
         FileHandle release(u64 fd);
+
+        /**
+         * @brief Erase any pointer to node.
+         *
+         * @param node The pointer to the node.
+         *
+         * @return Number of file handle erased.
+         *
+         * Iterate the store and erase any handles that has this node pointed by them.
+         */
+        usize erase(Node* node);
 
         FRange auto iter() { return sv::zip(m_nodes, m_modes); }
         FRange auto iter() const { return sv::zip(std::as_const(m_nodes), std::as_const(m_modes)); }

--- a/madbfs/include/madbfs/file_handle_store.hpp
+++ b/madbfs/include/madbfs/file_handle_store.hpp
@@ -85,7 +85,7 @@ namespace madbfs
         usize erase(Node* node);
 
         FRange auto iter() { return sv::zip(m_nodes, m_modes); }
-        FRange auto iter() const { return sv::zip(std::as_const(m_nodes), std::as_const(m_modes)); }
+        FRange auto iter() const { return sv::zip(m_nodes, m_modes); }
 
         usize size() const { return m_nodes.size(); }
 

--- a/madbfs/include/madbfs/filesystem.hpp
+++ b/madbfs/include/madbfs/filesystem.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "madbfs/path.hpp"
-#include "madbfs/tree/node.hpp"
+#include "madbfs/node.hpp"
 
 #include <functional>
 
@@ -10,28 +10,28 @@ namespace madbfs
     class Connection;
 }
 
-namespace madbfs::tree
+namespace madbfs
 {
     /**
-     * @class FileTree
+     * @class Filesystem
      *
-     * @brief A class representing a file tree structure.
+     * @brief A class representing the filesystem and its tree structure.
      *
      * This data structure is a Trie
      */
-    class FileTree
+    class Filesystem
     {
     public:
         using Filler = std::move_only_function<void(const char* name)>;
 
-        FileTree(Connection& connection, data::Cache& cache, Opt<Seconds> ttl);
-        ~FileTree() = default;
+        Filesystem(Connection& connection, data::Cache& cache, Opt<Seconds> ttl);
+        ~Filesystem() = default;
 
-        FileTree(Node&& root)            = delete;
-        FileTree& operator=(Node&& root) = delete;
+        Filesystem(Node&& root)            = delete;
+        Filesystem& operator=(Node&& root) = delete;
 
-        FileTree(const Node& root)            = delete;
-        FileTree& operator=(const Node& root) = delete;
+        Filesystem(const Node& root)            = delete;
+        Filesystem& operator=(const Node& root) = delete;
 
         /**
          * @brief Get a node by the given path.

--- a/madbfs/include/madbfs/filesystem.hpp
+++ b/madbfs/include/madbfs/filesystem.hpp
@@ -183,7 +183,6 @@ namespace madbfs
             return {
                 .connection = m_connection,
                 .cache      = m_cache,
-                .fd_counter = m_fd_counter,
                 .path       = path,
             };
         }
@@ -194,8 +193,7 @@ namespace madbfs
         Cache           m_cache;
         FileHandleStore m_handles;
 
-        Opt<Seconds>     m_ttl              = std::nullopt;
-        std::atomic<u64> m_fd_counter       = 0;
-        bool             m_root_initialized = false;
+        Opt<Seconds> m_ttl              = std::nullopt;
+        bool         m_root_initialized = false;
     };
 }

--- a/madbfs/include/madbfs/filesystem.hpp
+++ b/madbfs/include/madbfs/filesystem.hpp
@@ -58,8 +58,8 @@ namespace madbfs
 
         // fuse oprations
         // --------------
-        AExpect<void>            readdir(path::Path path, Filler filler);
-        AExpect<data::NamedStat> getattr(path::Path path);
+        AExpect<void>      readdir(path::Path path, Filler filler);
+        AExpect<NamedStat> getattr(path::Path path);
 
         AExpect<Str>       readlink(path::Path path);
         AExpect<Ref<Node>> mknod(path::Path path, mode_t mode, dev_t dev);
@@ -191,7 +191,7 @@ namespace madbfs
         Connection& m_connection;
 
         Node            m_root;
-        data::Cache     m_cache;
+        Cache           m_cache;
         FileHandleStore m_handles;
 
         Opt<Seconds>     m_ttl              = std::nullopt;

--- a/madbfs/include/madbfs/filesystem.hpp
+++ b/madbfs/include/madbfs/filesystem.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "madbfs/path.hpp"
+#include "madbfs/file_handle_store.hpp"
 #include "madbfs/node.hpp"
+#include "madbfs/path.hpp"
 
 #include <functional>
 
@@ -24,7 +25,22 @@ namespace madbfs
     public:
         using Filler = std::move_only_function<void(const char* name)>;
 
-        Filesystem(Connection& connection, data::Cache& cache, Opt<Seconds> ttl);
+        /**
+         * @brief Create a new filesystem.
+         *
+         * @param connection Reference to active conneciton to device.
+         * @param page_size Cache page size.
+         * @param max_pages Maximum number of pages to be saved on the cache.
+         * @param ttl Filesystem node's stat expiration time before re-fetching.
+         */
+        Filesystem(Connection& connection, usize page_size, usize max_pages, Opt<Seconds> ttl);
+
+        /**
+         * @brief Destroy filesystem.
+         *
+         * You must call `stop()` before destruction. Any asynchronous operation that is still happening may
+         * not be stopped correctly otherwise.
+         */
         ~Filesystem() = default;
 
         Filesystem(Node&& root)            = delete;
@@ -51,14 +67,14 @@ namespace madbfs
         AExpect<void>      unlink(path::Path path);
         AExpect<void>      rmdir(path::Path path);
         AExpect<void>      rename(path::Path from, path::Path to, u32 flags);
+        AExpect<void>      utimens(path::Path path, timespec atime, timespec mtime);
+        AExpect<void>      truncate(path::Path path, off_t size);
 
-        AExpect<void>  truncate(path::Path path, off_t size);
         AExpect<u64>   open(path::Path path, int flags);
-        AExpect<usize> read(path::Path path, u64 fd, Span<char> out, off_t offset);
-        AExpect<usize> write(path::Path path, u64 fd, Str in, off_t offset);
-        AExpect<void>  flush(path::Path path, u64 fd);
-        AExpect<void>  release(path::Path path, u64 fd);
-        AExpect<void>  utimens(path::Path path, timespec atime, timespec mtime);
+        AExpect<usize> read(u64 fd, Span<char> out, off_t offset);
+        AExpect<usize> write(u64 fd, Str in, off_t offset);
+        AExpect<void>  flush(u64 fd);
+        AExpect<void>  release(u64 fd);
 
         AExpect<usize> copy_file_range(
             path::Path in_path,
@@ -75,7 +91,14 @@ namespace madbfs
         Expect<void> symlink(path::Path path, Str target);
 
         /**
-         * @brief Set a new TTL for file tree nodes.
+         * @brief Shut down the filesystem and stop every async operation.
+         *
+         * Call this before destructor. This is needed to do proper flushing for the `Cache`.
+         */
+        Await<void> shutdown();
+
+        /**
+         * @brief Set a new TTL for file system nodes.
          *
          * @param ttl New TTl value (set to `std::nullopt` to disable)
          *
@@ -89,6 +112,15 @@ namespace madbfs
         usize expires_all();
 
         /**
+         * @brief Get cache structure.
+         */
+        template <typename Self>
+        auto&& cache(this Self&& self)
+        {
+            return std::forward_like<Self>(self.m_cache);
+        }
+
+        /**
          * @brief Get root node.
          */
         const Node& root() const { return m_root; }
@@ -99,6 +131,8 @@ namespace madbfs
          * If expiration is not enabled it will return `std::nullopt`.
          */
         Opt<Seconds> ttl() const { return m_ttl; }
+
+        FileHandleStore& handles() { return m_handles; }
 
     private:
         /**
@@ -154,11 +188,14 @@ namespace madbfs
             };
         }
 
-        Node             m_root;
-        Connection&      m_connection;
-        data::Cache&     m_cache;
+        Connection& m_connection;
+
+        Node            m_root;
+        data::Cache     m_cache;
+        FileHandleStore m_handles;
+
+        Opt<Seconds>     m_ttl              = std::nullopt;
         std::atomic<u64> m_fd_counter       = 0;
         bool             m_root_initialized = false;
-        Opt<Seconds>     m_ttl              = std::nullopt;
     };
 }

--- a/madbfs/include/madbfs/filesystem.hpp
+++ b/madbfs/include/madbfs/filesystem.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "madbfs/cache.hpp"
 #include "madbfs/file_handle_store.hpp"
 #include "madbfs/node.hpp"
 #include "madbfs/path.hpp"
+
+#include <madbfs-common/async/async.hpp>
 
 #include <functional>
 
@@ -184,20 +187,6 @@ namespace madbfs
          * it is a regular file.
          */
         Await<void> mutate_and_invalidate(Node& node, File file);
-
-        /**
-         * @brief Helper function to create context for node operations.
-         *
-         * @param path Path of the node operated on.
-         */
-        Node::Context make_context(const path::Path& path)
-        {
-            return {
-                .connection = m_connection,
-                .cache      = m_cache,
-                .path       = path,
-            };
-        }
 
         Connection& m_connection;
 

--- a/madbfs/include/madbfs/filesystem.hpp
+++ b/madbfs/include/madbfs/filesystem.hpp
@@ -171,7 +171,19 @@ namespace madbfs
          *
          * @param func The opeartion to be applied on each of the node.
          */
-        void walk(std::function<void(Node&)> func);
+        void walk(Node& start, std::function<void(Node&)> func);
+
+        /**
+         * @brief Replace the node variant with the new one while invalidating the current one.
+         *
+         * @param node Node to be mutated.
+         * @param file The new variant of the node.
+         *
+         * Invlidate here means removing the children (recursive) references from `Cache` as well as from
+         * `FileHandleStore` if the node is a directory. The funciton will remove references of the node if
+         * it is a regular file.
+         */
+        Await<void> mutate_and_invalidate(Node& node, File file);
 
         /**
          * @brief Helper function to create context for node operations.

--- a/madbfs/include/madbfs/madbfs.hpp
+++ b/madbfs/include/madbfs/madbfs.hpp
@@ -2,7 +2,7 @@
 
 #include "madbfs/args.hpp"
 #include "madbfs/connection.hpp"
-#include "madbfs/tree/file_tree.hpp"
+#include "madbfs/filesystem.hpp"
 
 #include <madbfs-common/ipc.hpp>
 
@@ -41,7 +41,7 @@ namespace madbfs
         Madbfs(const Madbfs&)            = delete;
         Madbfs& operator=(const Madbfs&) = delete;
 
-        tree::FileTree&    tree() { return m_tree; }
+        Filesystem&        filesystem() { return m_tree; }
         async::Context&    async_ctx() { return m_async_ctx; }
         const data::Cache& cache() const { return m_cache; }
 
@@ -102,7 +102,7 @@ namespace madbfs
 
         Connection       m_connection;
         data::Cache      m_cache;
-        tree::FileTree   m_tree;
+        Filesystem       m_tree;
         Opt<ipc::Server> m_ipc;
 
         async::Timer    m_watchdog_timer;

--- a/madbfs/include/madbfs/madbfs.hpp
+++ b/madbfs/include/madbfs/madbfs.hpp
@@ -41,9 +41,8 @@ namespace madbfs
         Madbfs(const Madbfs&)            = delete;
         Madbfs& operator=(const Madbfs&) = delete;
 
-        Filesystem&        filesystem() { return m_tree; }
-        async::Context&    async_ctx() { return m_async_ctx; }
-        const data::Cache& cache() const { return m_cache; }
+        Filesystem&     fs() { return m_fs; }
+        async::Context& ctx() { return m_async_ctx; }
 
         Str mountpoint() const { return m_mountpoint; }
 
@@ -101,8 +100,7 @@ namespace madbfs
         std::jthread     m_work_thread;
 
         Connection       m_connection;
-        data::Cache      m_cache;
-        Filesystem       m_tree;
+        Filesystem       m_fs;
         Opt<ipc::Server> m_ipc;
 
         async::Timer    m_watchdog_timer;

--- a/madbfs/include/madbfs/node.hpp
+++ b/madbfs/include/madbfs/node.hpp
@@ -12,14 +12,10 @@
 namespace madbfs
 {
     class Connection;
-}
-
-namespace madbfs::tree
-{
     class Node;
 }
 
-namespace madbfs::tree::node
+namespace madbfs::node
 {
     class Regular;
     class Directory;
@@ -201,7 +197,7 @@ namespace madbfs::tree::node
     };
 }
 
-namespace madbfs::tree
+namespace madbfs
 {
     using File = Var<node::Regular, node::Directory, node::Link, node::Other, node::Error>;
 
@@ -550,7 +546,7 @@ namespace madbfs::tree
 // template implementation
 // -----------------------
 
-namespace madbfs::tree
+namespace madbfs
 {
     template <typename T>
     bool Node::is() const

--- a/madbfs/include/madbfs/node.hpp
+++ b/madbfs/include/madbfs/node.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "madbfs/data/cache.hpp"
-#include "madbfs/data/stat.hpp"
+#include "madbfs/cache.hpp"
 #include "madbfs/path.hpp"
+#include "madbfs/stat.hpp"
 
 #include <atomic>
 #include <functional>
@@ -167,15 +167,15 @@ namespace madbfs
         struct Context
         {
             Connection&       connection;
-            data::Cache&      cache;
+            Cache&            cache;
             std::atomic<u64>& fd_counter;
             const path::Path& path;    // path for connection
         };
 
-        Node(Str name, Node* parent, data::Stat stat, File value)
+        Node(Str name, Node* parent, Stat stat, File value)
             : m_parent{ parent }
             , m_name{ name }
-            , m_id{ data::Id::incr() }
+            , m_id{ Id::incr() }
             , m_stat{ std::move(stat) }
             , m_value{ std::move(value) }
         {
@@ -187,17 +187,17 @@ namespace madbfs
         Node(const Node&)            = delete;
         Node& operator=(const Node&) = delete;
 
-        data::Id id() const { return m_id; };
+        Id id() const { return m_id; };
 
         void set_name(Str name) { m_name = name; }
         void set_parent(Node* parent) { m_parent = parent; }
-        void set_stat(data::Stat stat) { m_stat = stat; }
+        void set_stat(Stat stat) { m_stat = stat; }
 
         Str         name() const { return m_name; }
         Node*       parent() const { return m_parent; }
         const File& value() const { return m_value; }
 
-        Expect<Ref<const data::Stat>> stat() const;
+        Expect<Ref<const Stat>> stat() const;
 
         /**
          * @brief Set expiration from current time + duration.
@@ -290,7 +290,7 @@ namespace madbfs
          * operating on the file on the device itself, this function just modify the nodes. This function
          * assume that the build process won't overwrite any node.
          */
-        Expect<Ref<Node>> build(Str name, data::Stat stat, File file);
+        Expect<Ref<Node>> build(Str name, Stat stat, File file);
 
         /**
          * @brief Extract a child node.
@@ -382,7 +382,7 @@ namespace madbfs
          * @param context Context needed to communicate with device and local.
          * @param mode file open mode.
          */
-        AExpect<void> open(Context context, data::OpenMode mode);
+        AExpect<void> open(Context context, OpenMode mode);
 
         /**
          * @brief Read data from file.
@@ -422,7 +422,7 @@ namespace madbfs
          *
          * @param context Context needed to communicate with device and local.
          */
-        AExpect<void> release(Context context, data::OpenMode mode);
+        AExpect<void> release(Context context, OpenMode mode);
 
         /**
          * @brief Update the timestamps of a file.
@@ -480,12 +480,12 @@ namespace madbfs
             return as<node::Regular>();
         }
 
-        Node*      m_parent     = nullptr;
-        String     m_name       = {};
-        data::Id   m_id         = {};
-        data::Stat m_stat       = {};
-        Timepoint  m_expiration = Timepoint::max();
-        File       m_value;
+        Node*     m_parent     = nullptr;
+        String    m_name       = {};
+        Id        m_id         = {};
+        Stat      m_stat       = {};
+        Timepoint m_expiration = Timepoint::max();
+        File      m_value;
     };
 }
 

--- a/madbfs/include/madbfs/node.hpp
+++ b/madbfs/include/madbfs/node.hpp
@@ -4,7 +4,6 @@
 #include "madbfs/data/stat.hpp"
 #include "madbfs/path.hpp"
 
-#include <algorithm>
 #include <atomic>
 #include <functional>
 #include <unordered_set>
@@ -17,7 +16,7 @@ namespace madbfs
 
 namespace madbfs::node
 {
-    class Regular;
+    struct Regular;
     class Directory;
     struct Link;
     struct Other;
@@ -28,58 +27,9 @@ namespace madbfs::node
      *
      * @brief Represent a regular file.
      */
-    class Regular
+    struct Regular
     {
-    public:
-        friend Node;
-
-        using Mode = data::OpenMode;
-
-        struct Entry
-        {
-            u64  fd;
-            Mode mode;
-        };
-
-        Regular() = default;
-
-        /**
-         * @brief Insert `fd` into list of open files.
-         *
-         * @param fd File descriptor.
-         * @param flags Open flags.
-         *
-         * @return What the file current access mode after opening.
-         */
-        Mode open(u64 fd, int flags);
-
-        /**
-         * @brief Remove `fd` from list of open files.
-         *
-         * @param fd File descriptor.
-         *
-         * @return True if `fd` actually removed, false if fd can't be found.
-         */
-        Opt<Mode> close(u64 fd);
-
-        /**
-         * @brief Check the mode of the file.
-         *
-         * @param fd File descriptor.
-         * @param mode Mode to be checked.
-         *
-         * @return The function checks whether the fd can be operated on the least possible mode.
-         */
-        bool check(u64 fd, Mode mode) const;
-
-        bool is_open(u64 fd) const { return sr::find(m_open_fds, fd, &Entry::fd) != m_open_fds.end(); }
-        bool has_open_fds() const { return not m_open_fds.empty(); }
-        bool is_dirty() const { return m_dirty; }
-        void set_dirty(bool val) { m_dirty = val; }
-
-    private:
-        Vec<Entry> m_open_fds = {};
-        bool       m_dirty    = false;
+        bool dirty = false;
     };
 
     /**
@@ -430,11 +380,9 @@ namespace madbfs
          * @brief Open file.
          *
          * @param context Context needed to communicate with device and local.
-         * @param flags Open mode flags.
-         *
-         * @return File descriptor.
+         * @param mode file open mode.
          */
-        AExpect<u64> open(Context context, int flags);
+        AExpect<void> open(Context context, data::OpenMode mode);
 
         /**
          * @brief Read data from file.
@@ -464,18 +412,17 @@ namespace madbfs
          * @brief Flush buffer of the file.
          *
          * @param context Context needed to communicate with device and local.
-         * @param fd File descriptor.
          *
          * Basically forcing writing to the file itself instead of to the buffer in memory.
          */
-        AExpect<void> flush(Context context, u64 fd);
+        AExpect<void> flush(Context context);
 
         /**
          * @brief Release file.
          *
          * @param context Context needed to communicate with device and local.
          */
-        AExpect<void> release(Context context, u64 fd);
+        AExpect<void> release(Context context, data::OpenMode mode);
 
         /**
          * @brief Update the timestamps of a file.

--- a/madbfs/include/madbfs/node.hpp
+++ b/madbfs/include/madbfs/node.hpp
@@ -168,7 +168,6 @@ namespace madbfs
         {
             Connection&       connection;
             Cache&            cache;
-            std::atomic<u64>& fd_counter;
             const path::Path& path;    // path for connection
         };
 

--- a/madbfs/include/madbfs/node.hpp
+++ b/madbfs/include/madbfs/node.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "madbfs/cache.hpp"
 #include "madbfs/path.hpp"
 #include "madbfs/stat.hpp"
 
@@ -158,9 +157,6 @@ namespace madbfs
 {
     using File = Var<node::Regular, node::Directory, node::Link, node::Other, node::Error>;
 
-    constexpr auto timespec_now  = timespec{ .tv_sec = 0, .tv_nsec = UTIME_NOW };
-    constexpr auto timespec_omit = timespec{ .tv_sec = 0, .tv_nsec = UTIME_OMIT };
-
     /**
      * @class Node
      *
@@ -170,13 +166,6 @@ namespace madbfs
     {
     public:
         using Timepoint = SteadyClock::time_point;
-
-        struct Context
-        {
-            Connection&       connection;
-            Cache&            cache;
-            const path::Path& path;    // path for connection
-        };
 
         Node(Str name, Node* parent, Stat stat, File value)
             : m_parent{ parent }
@@ -198,12 +187,13 @@ namespace madbfs
         void set_name(Str name) { m_name = name; }
         void set_parent(Node* parent) { m_parent = parent; }
         void set_stat(Stat stat) { m_stat = stat; }
+        void set_size(off_t size) { m_stat.size = size; }
 
         Str         name() const { return m_name; }
         Node*       parent() const { return m_parent; }
         const File& value() const { return m_value; }
 
-        Expect<Ref<const Stat>> stat() const;
+        const Stat& stat() const { return m_stat; }
 
         /**
          * @brief Set expiration from current time + duration.
@@ -224,14 +214,6 @@ namespace madbfs
          * @return Old file variant.
          */
         File mutate(File file);
-
-        /**
-         * @brief Get Error ptr value if the variant is an Error.
-         *
-         * This function is different from `as<Error>` since it's intended for use outside of Node. It will
-         * return nullptr if the Node is not an Error instance.
-         */
-        const node::Error* as_error() const;
 
         /**
          * @brief Build path from node.
@@ -266,9 +248,6 @@ namespace madbfs
          */
         void set_synced(bool synced);
 
-        // operations on Directory
-        // -----------------------
-
         /**
          * @brief Traverse into child node.
          *
@@ -277,11 +256,6 @@ namespace madbfs
          * @return The child node.
          */
         Expect<Ref<Node>> traverse(Str name) const;
-
-        /**
-         * @brief List children of this node (only works on Directory else return error).
-         */
-        Expect<Ref<node::Directory::List>> list();
 
         /**
          * @brief Create a new node without any call to connection or cache with this node as its parent.
@@ -299,192 +273,34 @@ namespace madbfs
         Expect<Ref<Node>> build(Str name, Stat stat, File file);
 
         /**
-         * @brief Extract a child node.
-         *
-         * @param name The name of the node.
-         *
-         * @return The extracted node.
-         *
-         * Since it extracts a child node, it only works on Directory.
+         * @brief Get the regular file variant with various checks for other variants.
          */
-        Expect<Uniq<Node>> extract(Str name);
+        Expect<Ref<node::Regular>> regular_file_prelude();
 
         /**
-         * @brief Insert a node into another node.
-         *
-         * @param node The node to add.
-         * @param overwrite If true, overwrite the existing node with the same name.
-         *
-         * @return A pair containing the added node and overwriten node if overwrite happens.
-         *
-         * Since the insertion is basically adding a child node, it only works on Directory.
-         *
-         * - If insertion happen without overwrite, left will be non-null whereas right will be null.
-         * - If insertion happen with overwrite and flag enabled both will be non-null.
-         * - If overwrite happen when flag not enabled, error will be returned.
+         * @brief Get the directory variant with various checks for other variants.
          */
-        Expect<Pair<Ref<Node>, Uniq<Node>>> insert(Uniq<Node> node, bool overwrite);
+        Expect<Ref<node::Directory>> directory_prelude();
 
         /**
-         * @brief Create a new child node as Link.
+         * @brief Get Error ptr value if the variant is an Error.
          *
-         * @param name The name of the link.
-         * @param target The target of the link.
-         *
-         * @return The new link node.
+         * This function is different from `as<Error>` since it's intended for use outside of Node. It will
+         * return nullptr if the Node is not an Error instance.
          */
-        Expect<Ref<Node>> symlink(Str name, Str target);
-
-        /**
-         * @brief Create a new child node as Regular.
-         *
-         * @param context Context needed to communicate with device and local.
-         * @param mode File mode to use and the type of node to be created.
-         *
-         * @return The new regular file node.
-         */
-        AExpect<Ref<Node>> mknod(Context context, mode_t mode, dev_t dev);
-
-        /**
-         * @brief Create a new child node as Directory.
-         *
-         * @param context Context needed to communicate with device and local.
-         * @param mode The mode of the new directory.
-         *
-         * @return The new directory node.
-         */
-        AExpect<Ref<Node>> mkdir(Context context, mode_t mode);
-
-        /**
-         * @brief Remove a child node by its name (Regular or Directory).
-         *
-         * @param context Context needed to communicate with device and local.
-         */
-        AExpect<Uniq<Node>> unlink(Context context);
-
-        /**
-         * @brief Remove a child node by its name (Directory).
-         *
-         * @param context Context needed to communicate with device and local.
-         */
-        AExpect<void> rmdir(Context context);
-
-        // -----------------------
-
-        // operations on Regular
-        // -------------------------
-
-        /**
-         * @brief Truncate file.
-         *
-         * @param context Context needed to communicate with device and local.
-         * @param size The final size to truncate to.
-         */
-        AExpect<void> truncate(Context context, off_t size);
-
-        /**
-         * @brief Open file.
-         *
-         * @param context Context needed to communicate with device and local.
-         * @param mode file open mode.
-         */
-        AExpect<void> open(Context context, OpenMode mode);
-
-        /**
-         * @brief Read data from file.
-         *
-         * @param context Context needed to communicate with device and local.
-         * @param fd File descriptor.
-         * @param out The output of the data.
-         * @param offset Offset to the data to be read.
-         *
-         * @return The number of bytes read.
-         */
-        AExpect<usize> read(Context context, u64 fd, Span<char> out, off_t offset);
-
-        /**
-         * @brief Write data to file.
-         *
-         * @param context Context needed to communicate with device and local.
-         * @param fd File descriptor.
-         * @param in Data to be written.
-         * @param offset Offset of the write pointer.
-         *
-         * @return The number of bytes written.
-         */
-        AExpect<usize> write(Context context, u64 fd, Str in, off_t offset);
-
-        /**
-         * @brief Flush buffer of the file.
-         *
-         * @param context Context needed to communicate with device and local.
-         *
-         * Basically forcing writing to the file itself instead of to the buffer in memory.
-         */
-        AExpect<void> flush(Context context);
-
-        /**
-         * @brief Release file.
-         *
-         * @param context Context needed to communicate with device and local.
-         */
-        AExpect<void> release(Context context, OpenMode mode);
-
-        /**
-         * @brief Update the timestamps of a file.
-         *
-         * @param context Context needed to communicate with device and local.
-         */
-        AExpect<void> utimens(Context context, timespec atime, timespec mtime);
-
-        // -------------------------
-
-        // operations on Link
-        // ------------------
-
-        /**
-         * @brief Read a link.
-         */
-        Expect<Str> readlink();
-
-        // ------------------
-
-    private:
-        inline static std::atomic<u64> s_id_counter = 0;
+        const node::Error* as_error() const;
 
         template <typename T>
         bool is() const;
 
         template <typename T>
-        Expect<Ref<T>> as();
+        Expect<Ref<T>> as(bool check_error = false);
 
         template <typename T>
-        Expect<Ref<const T>> as() const;
+        Expect<Ref<const T>> as(bool check_error = false) const;
 
-        Expect<Ref<node::Regular>> regular_file_prelude()
-        {
-            if (is<node::Link>()) {
-                // ELOOP, mimicking open(2) behavior when O_NOFOLLOW option specified
-                return Unexpect{ Errc::too_many_symbolic_link_levels };
-            }
-
-            if (auto err = as<node::Error>(); err.has_value()) {
-                return Unexpect{ err->get().error };
-            }
-
-            if (is<node::Directory>()) {
-                return Unexpect{ Errc::is_a_directory };
-            } else if (is<node::Other>()) {
-                // NOTE: reading/writing special files (excluding symlink) is not possible by FUSE alone. One
-                // can present them by disguising it as regular files though.
-                //
-                // read: - https://github.com/rpodgorny/unionfs-fuse/issues/66
-                //       - https://github.com/libfuse/libfuse/issues/182
-                return Unexpect{ Errc::operation_not_supported };
-            }
-
-            return as<node::Regular>();
-        }
+    private:
+        inline static std::atomic<u64> s_id_counter = 0;
 
         Node*     m_parent     = nullptr;
         String    m_name       = {};
@@ -508,34 +324,32 @@ namespace madbfs
     }
 
     template <typename T>
-    Expect<Ref<T>> Node::as()
+    Expect<Ref<T>> Node::as(bool check_error)
     {
-        constexpr auto errc = [&] {
-            if constexpr (std::same_as<node::Directory, T>) {
-                return Errc::not_a_directory;
-            } else {
-                return Errc::invalid_argument;
+        if (check_error) {
+            if (auto* err = std::get_if<node::Error>(&m_value)) {
+                return Unexpect{ err->error };
             }
-        }();
+        }
         if (auto* val = std::get_if<T>(&m_value)) {
             return *val;
         }
+        auto errc = std::same_as<node::Directory, T> ? Errc::not_a_directory : Errc::invalid_argument;
         return Unexpect{ errc };
     }
 
     template <typename T>
-    Expect<Ref<const T>> Node::as() const
+    Expect<Ref<const T>> Node::as(bool check_error) const
     {
-        constexpr auto errc = [] {
-            if constexpr (std::same_as<node::Directory, T>) {
-                return Errc::not_a_directory;
-            } else {
-                return Errc::invalid_argument;
+        if (check_error) {
+            if (auto* err = std::get_if<node::Error>(&m_value)) {
+                return Unexpect{ err->error };
             }
-        }();
+        }
         if (auto* val = std::get_if<T>(&m_value)) {
             return *val;
         }
+        auto errc = std::same_as<node::Directory, T> ? Errc::not_a_directory : Errc::invalid_argument;
         return Unexpect{ errc };
     }
 }

--- a/madbfs/include/madbfs/node.hpp
+++ b/madbfs/include/madbfs/node.hpp
@@ -77,9 +77,12 @@ namespace madbfs::node
          * @brief Erase a file by its name.
          *
          * @param name The file name.
-         * @return True if file deleted, false if the file does not exist.
+         *
+         * @return The erased node, else `std::nullopt` if not exists
+         *
+         * This function is semantically the same with `extract()`.
          */
-        bool erase(Str name);
+        Opt<Uniq<Node>> erase(Str name);
 
         /**
          * @brief Add a new node.
@@ -99,6 +102,10 @@ namespace madbfs::node
          * @brief Extract a node.
          *
          * @param name The name of the node.
+         *
+         * @return The node or `Errc::no_such_file_or_directory`
+         *
+         * This function is semantically the same with `erase()`.
          */
         Expect<Uniq<Node>> extract(Str name);
 
@@ -353,7 +360,7 @@ namespace madbfs
          *
          * @param context Context needed to communicate with device and local.
          */
-        AExpect<void> unlink(Context context);
+        AExpect<Uniq<Node>> unlink(Context context);
 
         /**
          * @brief Remove a child node by its name (Directory).

--- a/madbfs/include/madbfs/stat.hpp
+++ b/madbfs/include/madbfs/stat.hpp
@@ -11,7 +11,7 @@ namespace madbfs
     class Node;
 }
 
-namespace madbfs::data
+namespace madbfs
 {
     /**
      * @class CacheId
@@ -67,8 +67,8 @@ namespace madbfs::data
      */
     struct NamedStat
     {
-        data::Id   id;
-        data::Stat stat;
+        Id   id;
+        Stat stat;
     };
 
     /**

--- a/madbfs/include/madbfs/transport/null_transport.hpp
+++ b/madbfs/include/madbfs/transport/null_transport.hpp
@@ -27,15 +27,8 @@ namespace madbfs::transport
         void        stop(rpc::Status) override { }
         Await<void> start() override { co_return; }
 
-        AExpect<rpc::Response> send(rpc::Request req) override
-        {
-            co_return Unexpect{ m_errc };
-        }
-
-        AExpect<rpc::Response> send(rpc::Request req, Milliseconds timeout) override
-        {
-            co_return Unexpect{ m_errc };
-        }
+        AExpect<rpc::Response> send(rpc::Request) override { co_return Unexpect{ m_errc }; }
+        AExpect<rpc::Response> send(rpc::Request, Milliseconds) override { co_return Unexpect{ m_errc }; }
 
     private:
         Errc m_errc;

--- a/madbfs/src/cache.cpp
+++ b/madbfs/src/cache.cpp
@@ -1,4 +1,4 @@
-#include "madbfs/data/cache.hpp"
+#include "madbfs/cache.hpp"
 
 #include "madbfs/connection.hpp"
 
@@ -7,14 +7,14 @@
 
 namespace
 {
-    auto scoped_increment(madbfs::i64& counter)
+    madbfs::util::Deferred auto scoped_increment(madbfs::i64& counter)
     {
         ++counter;
         return madbfs::util::defer([&] { --counter; });
     }
 }
 
-namespace madbfs::data
+namespace madbfs
 {
     Page::Page(PageKey key, Uniq<char[]> buf, u32 size, u32 page_size)
         : m_key{ key }
@@ -73,7 +73,7 @@ namespace madbfs::data
     }
 }
 
-namespace madbfs::data
+namespace madbfs
 {
     Cache::Cache(Connection& connection, usize page_size, usize max_pages)
         : m_connection{ connection }
@@ -82,7 +82,7 @@ namespace madbfs::data
     {
     }
 
-    AExpect<void> Cache::hint_open(Id id, path::Path path, data::OpenMode mode)
+    AExpect<void> Cache::hint_open(Id id, path::Path path, OpenMode mode)
     {
         // only adding new entry, actual open will be performed on read/write
         log_d(__func__, "[id={}|mode={}] {:?} ", id.inner(), std::to_underlying(mode), path);
@@ -96,8 +96,8 @@ namespace madbfs::data
         const auto prev_reader = entry.reader;
         const auto prev_writer = entry.writer;
 
-        entry.reader += mode == data::OpenMode::Read or mode == data::OpenMode::ReadWrite;
-        entry.writer += mode == data::OpenMode::Write or mode == data::OpenMode::ReadWrite;
+        entry.reader += mode == OpenMode::Read or mode == OpenMode::ReadWrite;
+        entry.writer += mode == OpenMode::Write or mode == OpenMode::ReadWrite;
 
         // see note on clean_stale_fds() function body regarding m_stale_fds
 
@@ -113,7 +113,7 @@ namespace madbfs::data
         co_return Expect<void>{};
     }
 
-    AExpect<void> Cache::hint_close(Id id, data::OpenMode mode)
+    AExpect<void> Cache::hint_close(Id id, OpenMode mode)
     {
         // only mark id's fd as stale on empty reader/writer, actual close performed on clean_stale_fds()
         log_d(__func__, "[id={}|mode={}]", id.inner(), std::to_underlying(mode));
@@ -126,8 +126,8 @@ namespace madbfs::data
 
         auto& entry = may_entry->get();
 
-        auto reader_decr = mode == data::OpenMode::Read or mode == data::OpenMode::ReadWrite;
-        auto writer_decr = mode == data::OpenMode::Write or mode == data::OpenMode::ReadWrite;
+        auto reader_decr = mode == OpenMode::Read or mode == OpenMode::ReadWrite;
+        auto writer_decr = mode == OpenMode::Write or mode == OpenMode::ReadWrite;
 
         if ((reader_decr and entry.reader == 0) or (writer_decr and entry.writer == 0)) {
             log_e(__func__, "[{}] closed too many times", id.inner());
@@ -223,7 +223,7 @@ namespace madbfs::data
         log_d(__func__, "flush: start [id={}|idx={}]", id.inner(), pages | sv::keys);
 
         if (auto& e = entry->get(); not e.write_fd) {
-            auto fd = co_await m_connection.open(e.path, data::OpenMode::Write);
+            auto fd = co_await m_connection.open(e.path, OpenMode::Write);
             if (not fd) {
                 co_return Unexpect{ fd.error() };
             }
@@ -521,7 +521,7 @@ namespace madbfs::data
                 auto write_incr_lock = scoped_increment(entry->get().write_inflight);
 
                 if (auto& e = entry->get(); not e.write_fd) {
-                    auto fd = co_await m_connection.open(e.path, data::OpenMode::Write);
+                    auto fd = co_await m_connection.open(e.path, OpenMode::Write);
                     if (not fd) {
                         log_c(__func__, "force push [id={}|idx={}] can't open file", id.inner(), idx);
                         continue;
@@ -568,7 +568,7 @@ namespace madbfs::data
         if (page_entry == entry.pages.end()) {
             // cache miss
             if (not entry.read_fd) {
-                auto fd = co_await m_connection.open(entry.path, data::OpenMode::Read);
+                auto fd = co_await m_connection.open(entry.path, OpenMode::Read);
                 if (not fd) {
                     co_return Unexpect{ fd.error() };
                 }
@@ -711,6 +711,9 @@ namespace madbfs::data
                 co_return Unexpect{ err };
             }
         }
+
+        // TODO: maybe add queue as well like m_read_queue to prevent data being written by other operations
+        // before flush finish?
 
         auto written = 0uz;
         while (written < page.size()) {

--- a/madbfs/src/connection.cpp
+++ b/madbfs/src/connection.cpp
@@ -195,7 +195,7 @@ namespace madbfs
         auto generator = [](Vec<u8> buf, Vec<Pair<Str, rpc::resp::Stat>> entries) -> Gen<ParsedStat> {
             for (const auto& [name, stat] : entries) {
                 co_yield ParsedStat{
-                    .stat = data::Stat {
+                    .stat = Stat{
                         .links = stat.links,
                         .size  = stat.size,
                         .mtime = stat.mtime,
@@ -213,12 +213,12 @@ namespace madbfs
         co_return generator(std::move(buf), std::move(resp).value().entries);
     }
 
-    AExpect<data::Stat> Connection::stat(path::Path path)
+    AExpect<Stat> Connection::stat(path::Path path)
     {
         auto req = rpc::req::Stat{ .path = path };
 
         co_return (co_await send_req(req)).transform([](rpc::resp::Stat resp) {
-            return data::Stat{
+            return Stat{
                 .links = resp.links,
                 .size  = resp.size,
                 .mtime = resp.mtime,
@@ -302,7 +302,7 @@ namespace madbfs
         co_return (co_await send_req(req)).transform(proj(&rpc::resp::CopyFileRange::size));
     }
 
-    AExpect<u64> Connection::open(path::Path path, data::OpenMode mode)
+    AExpect<u64> Connection::open(path::Path path, OpenMode mode)
     {
         auto req = rpc::req::Open{ .path = path, .mode = static_cast<rpc::OpenMode>(mode) };
         co_return (co_await send_req(req)).transform(proj(&rpc::resp::Open::fd));

--- a/madbfs/src/file_handle_store.cpp
+++ b/madbfs/src/file_handle_store.cpp
@@ -9,19 +9,19 @@ namespace madbfs
         return fd < m_nodes.size() ? FileHandle{ m_nodes[fd], m_modes[fd] } : FileHandle{};
     }
 
-    Node* FileHandleStore::find(u64 fd, data::OpenMode mode)
+    Node* FileHandleStore::find(u64 fd, OpenMode mode)
     {
         if (fd >= m_nodes.size()) {
             return nullptr;
         }
 
-        auto ok   = m_modes[fd] == mode or m_modes[fd] == data::OpenMode::ReadWrite;
+        auto ok   = m_modes[fd] == mode or m_modes[fd] == OpenMode::ReadWrite;
         auto node = m_nodes[fd];
 
         return node and ok ? node : nullptr;
     }
 
-    u64 FileHandleStore::store(Node* node, data::OpenMode mode)
+    u64 FileHandleStore::store(Node* node, OpenMode mode)
     {
         if (auto found = sr::find(m_nodes, nullptr); found != m_nodes.end()) {
             auto dist     = static_cast<usize>(found - m_nodes.begin());

--- a/madbfs/src/file_handle_store.cpp
+++ b/madbfs/src/file_handle_store.cpp
@@ -1,0 +1,55 @@
+#include "madbfs/file_handle_store.hpp"
+
+#include "madbfs/node.hpp"
+
+namespace madbfs
+{
+    FileHandle FileHandleStore::find(u64 fd)
+    {
+        return fd < m_nodes.size() ? FileHandle{ m_nodes[fd], m_modes[fd] } : FileHandle{};
+    }
+
+    Node* FileHandleStore::find(u64 fd, data::OpenMode mode)
+    {
+        if (fd >= m_nodes.size()) {
+            return nullptr;
+        }
+
+        auto ok   = m_modes[fd] == mode or m_modes[fd] == data::OpenMode::ReadWrite;
+        auto node = m_nodes[fd];
+
+        return node and ok ? node : nullptr;
+    }
+
+    u64 FileHandleStore::store(Node* node, data::OpenMode mode)
+    {
+        if (auto found = sr::find(m_nodes, nullptr); found != m_nodes.end()) {
+            auto dist     = static_cast<usize>(found - m_nodes.begin());
+            m_nodes[dist] = node;
+            m_modes[dist] = mode;
+            return dist;
+        }
+
+        auto size = m_nodes.size();
+
+        if (m_nodes.empty()) {
+            m_nodes.resize(1024, {});    // 1024 seats by default is reasonable I guess
+            m_modes.resize(1024, {});
+        } else {
+            m_nodes.resize(size * 2, {});    // should I add upper limit?
+            m_modes.resize(size * 2, {});
+        }
+
+        m_nodes[size] = node;
+        m_modes[size] = mode;
+
+        return size;
+    }
+
+    FileHandle FileHandleStore::release(u64 fd)
+    {
+        return fd < m_nodes.size()
+                 ? FileHandle{ std::exchange(m_nodes[fd], {}), std::exchange(m_modes[fd], {}) }
+                 : FileHandle{};
+    }
+}

--- a/madbfs/src/file_handle_store.cpp
+++ b/madbfs/src/file_handle_store.cpp
@@ -52,4 +52,16 @@ namespace madbfs
                  ? FileHandle{ std::exchange(m_nodes[fd], {}), std::exchange(m_modes[fd], {}) }
                  : FileHandle{};
     }
+
+    usize FileHandleStore::erase(Node* node)
+    {
+        auto count = 0uz;
+        for (auto& v : m_nodes) {
+            if (v == node) {
+                v = nullptr;
+                ++count;
+            }
+        }
+        return count;
+    }
 }

--- a/madbfs/src/file_handle_store.cpp
+++ b/madbfs/src/file_handle_store.cpp
@@ -2,6 +2,8 @@
 
 #include "madbfs/node.hpp"
 
+#include <utility>
+
 namespace madbfs
 {
     FileHandle FileHandleStore::find(u64 fd)

--- a/madbfs/src/filesystem.cpp
+++ b/madbfs/src/filesystem.cpp
@@ -9,10 +9,10 @@
 
 namespace madbfs
 {
-    Filesystem::Filesystem(Connection& connection, data::Cache& cache, Opt<Seconds> ttl)
-        : m_root{ "/", nullptr, {}, node::Directory{} }
-        , m_connection{ connection }
-        , m_cache{ cache }
+    Filesystem::Filesystem(Connection& connection, usize page_size, usize max_pages, Opt<Seconds> ttl)
+        : m_connection{ connection }
+        , m_root{ "/", nullptr, {}, node::Directory{} }
+        , m_cache{ m_connection, page_size, max_pages }
         , m_ttl{ ttl }
     {
     }
@@ -458,6 +458,15 @@ namespace madbfs
         co_return Expect<void>{};
     }
 
+    AExpect<void> Filesystem::utimens(path::Path path, timespec atime, timespec mtime)
+    {
+        auto node = co_await traverse_or_build(path);
+        if (not node) {
+            co_return Unexpect{ node.error() };
+        }
+        co_return co_await node->get().utimens(make_context(path), atime, mtime);
+    }
+
     AExpect<void> Filesystem::truncate(path::Path path, off_t size)
     {
         auto node = co_await traverse_or_build(path);
@@ -473,43 +482,45 @@ namespace madbfs
         if (not node) {
             co_return Unexpect{ node.error() };
         }
-        co_return co_await node->get().open(make_context(path), flags);
+        auto mode = static_cast<data::OpenMode>(O_ACCMODE & flags);
+        co_return (co_await node->get().open(make_context(path), mode)).transform([&] {
+            return m_handles.store(&node->get(), mode);
+        });
     }
 
-    AExpect<usize> Filesystem::read(path::Path path, u64 fd, Span<char> out, off_t offset)
+    AExpect<usize> Filesystem::read(u64 fd, Span<char> out, off_t offset)
     {
-        auto node = co_await traverse_or_build(path);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        if (auto node = m_handles.find(fd, data::OpenMode::Read); node) {
+            co_return co_await node->read(make_context({}), fd, out, offset);
         }
-        co_return co_await node->get().read(make_context(path), fd, out, offset);
+        co_return Unexpect{ Errc::bad_file_descriptor };
     }
 
-    AExpect<usize> Filesystem::write(path::Path path, u64 fd, Str in, off_t offset)
+    AExpect<usize> Filesystem::write(u64 fd, Str in, off_t offset)
     {
-        auto node = co_await traverse_or_build(path);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        if (auto node = m_handles.find(fd, data::OpenMode::Write); node) {
+            co_return co_await node->write(make_context({}), fd, in, offset);
         }
-        co_return co_await node->get().write(make_context(path), fd, in, offset);
+        co_return Unexpect{ Errc::bad_file_descriptor };
     }
 
-    AExpect<void> Filesystem::flush(path::Path path, u64 fd)
+    AExpect<void> Filesystem::flush(u64 fd)
     {
-        auto node = co_await traverse_or_build(path);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        if (auto [node, _] = m_handles.find(fd); node) {
+            co_return co_await node->flush(make_context({}));
         }
-        co_return co_await node->get().flush(make_context(path), fd);
+        co_return Unexpect{ Errc::bad_file_descriptor };
     }
 
-    AExpect<void> Filesystem::release(path::Path path, u64 fd)
+    AExpect<void> Filesystem::release(u64 fd)
     {
-        auto node = co_await traverse_or_build(path);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        if (auto [node, mode] = m_handles.release(fd); node) {
+            co_return (co_await node->release(make_context({}), mode)).transform_error([&](Errc err) {
+                m_handles.store(node, mode);    // if fail, do I need to store it again?
+                return err;
+            });
         }
-        co_return co_await node->get().release(make_context(path), fd);
+        co_return Unexpect{ Errc::bad_file_descriptor };
     }
 
     AExpect<usize> Filesystem::copy_file_range(
@@ -523,8 +534,8 @@ namespace madbfs
     )
     {
         // just in-case they have dirty pages
-        std::ignore = co_await flush(in_path, in_fd);
-        std::ignore = co_await flush(out_path, out_fd);
+        std::ignore = co_await flush(in_fd);
+        std::ignore = co_await flush(out_fd);
 
         auto node = traverse(out_path);    // path must exist
         if (not node) {
@@ -542,20 +553,16 @@ namespace madbfs
         });
     }
 
-    AExpect<void> Filesystem::utimens(path::Path path, timespec atime, timespec mtime)
-    {
-        auto node = co_await traverse_or_build(path);
-        if (not node) {
-            co_return Unexpect{ node.error() };
-        }
-        co_return co_await node->get().utimens(make_context(path), atime, mtime);
-    }
-
     Expect<void> Filesystem::symlink(path::Path path, Str target)
     {
         return traverse(path.parent_path())
             .and_then(proj(&Node::symlink, path.filename(), target))
             .transform(sink_void);
+    }
+
+    Await<void> Filesystem::shutdown()
+    {
+        co_await m_cache.shutdown();
     }
 
     Opt<Seconds> Filesystem::set_ttl(Opt<Seconds> ttl)
@@ -573,6 +580,7 @@ namespace madbfs
 
         return old;
     }
+
     usize Filesystem::expires_all()
     {
         auto count = 0uz;

--- a/madbfs/src/filesystem.cpp
+++ b/madbfs/src/filesystem.cpp
@@ -1,15 +1,15 @@
-#include "madbfs/tree/file_tree.hpp"
+#include "madbfs/filesystem.hpp"
 
 #include "madbfs/connection.hpp"
-#include "madbfs/tree/node.hpp"
+#include "madbfs/node.hpp"
 
 #include <madbfs-common/log.hpp>
 
 #include <fmt/std.h>
 
-namespace madbfs::tree
+namespace madbfs
 {
-    FileTree::FileTree(Connection& connection, data::Cache& cache, Opt<Seconds> ttl)
+    Filesystem::Filesystem(Connection& connection, data::Cache& cache, Opt<Seconds> ttl)
         : m_root{ "/", nullptr, {}, node::Directory{} }
         , m_connection{ connection }
         , m_cache{ cache }
@@ -17,7 +17,7 @@ namespace madbfs::tree
     {
     }
 
-    AExpect<Ref<Node>> FileTree::build(Node& parent, path::Path path)
+    AExpect<Ref<Node>> Filesystem::build(Node& parent, path::Path path)
     {
         const auto name = path.filename();
 
@@ -50,7 +50,7 @@ namespace madbfs::tree
         }
     }
 
-    AExpect<Ref<Node>> FileTree::build_directory(Node& parent, path::Path path)
+    AExpect<Ref<Node>> Filesystem::build_directory(Node& parent, path::Path path)
     {
         const auto name = path.filename();
 
@@ -74,7 +74,7 @@ namespace madbfs::tree
         co_return build_then_expire(name, *stat, node::Directory{});
     }
 
-    Expect<Ref<Node>> FileTree::traverse(path::Path path)
+    Expect<Ref<Node>> Filesystem::traverse(path::Path path)
     {
         if (path.is_root()) {
             return m_root;
@@ -93,7 +93,7 @@ namespace madbfs::tree
         return *current;
     }
 
-    AExpect<Ref<Node>> FileTree::traverse_or_build(path::Path path)
+    AExpect<Ref<Node>> Filesystem::traverse_or_build(path::Path path)
     {
         if (path.is_root()) {
             // workaround to initialize root stat on getattr
@@ -145,7 +145,7 @@ namespace madbfs::tree
         co_return co_await build(*current, current_path);
     }
 
-    AExpect<void> FileTree::update(Node& node, path::Path path)
+    AExpect<void> Filesystem::update(Node& node, path::Path path)
     {
         log_d(__func__, "{:?}", path);
 
@@ -209,7 +209,7 @@ namespace madbfs::tree
         co_return Expect<void>{};
     }
 
-    void FileTree::walk(std::function<void(Node&)> func)
+    void Filesystem::walk(std::function<void(Node&)> func)
     {
         auto stack = Vec<Node*>{ &m_root };
 
@@ -227,7 +227,7 @@ namespace madbfs::tree
         }
     }
 
-    AExpect<void> FileTree::readdir(path::Path path, Filler filler)
+    AExpect<void> Filesystem::readdir(path::Path path, Filler filler)
     {
         auto parent = &m_root;
 
@@ -343,7 +343,7 @@ namespace madbfs::tree
         co_return Expect<void>{};
     }
 
-    AExpect<data::NamedStat> FileTree::getattr(path::Path path)
+    AExpect<data::NamedStat> Filesystem::getattr(path::Path path)
     {
         co_return (co_await traverse_or_build(path)).and_then([](Node& node) {
             return node.stat().transform([id = node.id()](const data::Stat& stat) {
@@ -352,12 +352,12 @@ namespace madbfs::tree
         });
     }
 
-    AExpect<Str> FileTree::readlink(path::Path path)
+    AExpect<Str> Filesystem::readlink(path::Path path)
     {
         co_return (co_await traverse_or_build(path)).and_then(&Node::readlink);
     }
 
-    AExpect<Ref<Node>> FileTree::mknod(path::Path path, mode_t mode, dev_t dev)
+    AExpect<Ref<Node>> Filesystem::mknod(path::Path path, mode_t mode, dev_t dev)
     {
         auto parent = path.parent_path();
         auto node   = co_await traverse_or_build(parent);
@@ -367,7 +367,7 @@ namespace madbfs::tree
         co_return co_await node->get().mknod(make_context(path), mode, dev);
     }
 
-    AExpect<Ref<Node>> FileTree::mkdir(path::Path path, mode_t mode)
+    AExpect<Ref<Node>> Filesystem::mkdir(path::Path path, mode_t mode)
     {
         auto parent = path.parent_path();
         auto node   = co_await traverse_or_build(parent);
@@ -377,7 +377,7 @@ namespace madbfs::tree
         co_return co_await node->get().mkdir(make_context(path), mode);
     }
 
-    AExpect<void> FileTree::unlink(path::Path path)
+    AExpect<void> Filesystem::unlink(path::Path path)
     {
         auto parent = path.parent_path();
         auto node   = co_await traverse_or_build(parent);
@@ -387,7 +387,7 @@ namespace madbfs::tree
         co_return co_await node->get().unlink(make_context(path));
     }
 
-    AExpect<void> FileTree::rmdir(path::Path path)
+    AExpect<void> Filesystem::rmdir(path::Path path)
     {
         auto parent = path.parent_path();
         auto node   = co_await traverse_or_build(parent);
@@ -397,7 +397,7 @@ namespace madbfs::tree
         co_return co_await node->get().rmdir(make_context(path));
     }
 
-    AExpect<void> FileTree::rename(path::Path from, path::Path to, u32 flags)
+    AExpect<void> Filesystem::rename(path::Path from, path::Path to, u32 flags)
     {
         // I don't think root can be moved, :P
         if (from.is_root()) {
@@ -458,7 +458,7 @@ namespace madbfs::tree
         co_return Expect<void>{};
     }
 
-    AExpect<void> FileTree::truncate(path::Path path, off_t size)
+    AExpect<void> Filesystem::truncate(path::Path path, off_t size)
     {
         auto node = co_await traverse_or_build(path);
         if (not node) {
@@ -467,7 +467,7 @@ namespace madbfs::tree
         co_return co_await node->get().truncate(make_context(path), size);
     }
 
-    AExpect<u64> FileTree::open(path::Path path, int flags)
+    AExpect<u64> Filesystem::open(path::Path path, int flags)
     {
         auto node = co_await traverse_or_build(path);
         if (not node) {
@@ -476,7 +476,7 @@ namespace madbfs::tree
         co_return co_await node->get().open(make_context(path), flags);
     }
 
-    AExpect<usize> FileTree::read(path::Path path, u64 fd, Span<char> out, off_t offset)
+    AExpect<usize> Filesystem::read(path::Path path, u64 fd, Span<char> out, off_t offset)
     {
         auto node = co_await traverse_or_build(path);
         if (not node) {
@@ -485,7 +485,7 @@ namespace madbfs::tree
         co_return co_await node->get().read(make_context(path), fd, out, offset);
     }
 
-    AExpect<usize> FileTree::write(path::Path path, u64 fd, Str in, off_t offset)
+    AExpect<usize> Filesystem::write(path::Path path, u64 fd, Str in, off_t offset)
     {
         auto node = co_await traverse_or_build(path);
         if (not node) {
@@ -494,7 +494,7 @@ namespace madbfs::tree
         co_return co_await node->get().write(make_context(path), fd, in, offset);
     }
 
-    AExpect<void> FileTree::flush(path::Path path, u64 fd)
+    AExpect<void> Filesystem::flush(path::Path path, u64 fd)
     {
         auto node = co_await traverse_or_build(path);
         if (not node) {
@@ -503,7 +503,7 @@ namespace madbfs::tree
         co_return co_await node->get().flush(make_context(path), fd);
     }
 
-    AExpect<void> FileTree::release(path::Path path, u64 fd)
+    AExpect<void> Filesystem::release(path::Path path, u64 fd)
     {
         auto node = co_await traverse_or_build(path);
         if (not node) {
@@ -512,7 +512,7 @@ namespace madbfs::tree
         co_return co_await node->get().release(make_context(path), fd);
     }
 
-    AExpect<usize> FileTree::copy_file_range(
+    AExpect<usize> Filesystem::copy_file_range(
         path::Path in_path,
         u64        in_fd,
         off_t      in_off,
@@ -542,7 +542,7 @@ namespace madbfs::tree
         });
     }
 
-    AExpect<void> FileTree::utimens(path::Path path, timespec atime, timespec mtime)
+    AExpect<void> Filesystem::utimens(path::Path path, timespec atime, timespec mtime)
     {
         auto node = co_await traverse_or_build(path);
         if (not node) {
@@ -551,14 +551,14 @@ namespace madbfs::tree
         co_return co_await node->get().utimens(make_context(path), atime, mtime);
     }
 
-    Expect<void> FileTree::symlink(path::Path path, Str target)
+    Expect<void> Filesystem::symlink(path::Path path, Str target)
     {
         return traverse(path.parent_path())
             .and_then(proj(&Node::symlink, path.filename(), target))
             .transform(sink_void);
     }
 
-    Opt<Seconds> FileTree::set_ttl(Opt<Seconds> ttl)
+    Opt<Seconds> Filesystem::set_ttl(Opt<Seconds> ttl)
     {
         auto old = std::exchange(m_ttl, ttl);
         if (old == ttl) {
@@ -573,7 +573,7 @@ namespace madbfs::tree
 
         return old;
     }
-    usize FileTree::expires_all()
+    usize Filesystem::expires_all()
     {
         auto count = 0uz;
         walk([&](Node& node) { ++count, node.expires_after(Seconds{ 0 }); });

--- a/madbfs/src/filesystem.cpp
+++ b/madbfs/src/filesystem.cpp
@@ -21,7 +21,7 @@ namespace madbfs
     {
         const auto name = path.filename();
 
-        auto build_then_expire = [&](Str name, data::Stat stat, File file) {
+        auto build_then_expire = [&](Str name, Stat stat, File file) {
             return parent    //
                 .build(name, std::move(stat), std::move(file))
                 .transform([&](Node& node) {
@@ -54,7 +54,7 @@ namespace madbfs
     {
         const auto name = path.filename();
 
-        auto build_then_expire = [&](Str name, data::Stat stat, File file) {
+        auto build_then_expire = [&](Str name, Stat stat, File file) {
             return parent    //
                 .build(name, std::move(stat), std::move(file))
                 .transform([&](Node& node) {
@@ -343,11 +343,11 @@ namespace madbfs
         co_return Expect<void>{};
     }
 
-    AExpect<data::NamedStat> Filesystem::getattr(path::Path path)
+    AExpect<NamedStat> Filesystem::getattr(path::Path path)
     {
         co_return (co_await traverse_or_build(path)).and_then([](Node& node) {
-            return node.stat().transform([id = node.id()](const data::Stat& stat) {
-                return data::NamedStat{ .id = id, .stat = stat };
+            return node.stat().transform([id = node.id()](const Stat& stat) {
+                return NamedStat{ .id = id, .stat = stat };
             });
         });
     }
@@ -482,7 +482,7 @@ namespace madbfs
         if (not node) {
             co_return Unexpect{ node.error() };
         }
-        auto mode = static_cast<data::OpenMode>(O_ACCMODE & flags);
+        auto mode = static_cast<OpenMode>(O_ACCMODE & flags);
         co_return (co_await node->get().open(make_context(path), mode)).transform([&] {
             return m_handles.store(&node->get(), mode);
         });
@@ -490,7 +490,7 @@ namespace madbfs
 
     AExpect<usize> Filesystem::read(u64 fd, Span<char> out, off_t offset)
     {
-        if (auto node = m_handles.find(fd, data::OpenMode::Read); node) {
+        if (auto node = m_handles.find(fd, OpenMode::Read); node) {
             co_return co_await node->read(make_context({}), fd, out, offset);
         }
         co_return Unexpect{ Errc::bad_file_descriptor };
@@ -498,7 +498,7 @@ namespace madbfs
 
     AExpect<usize> Filesystem::write(u64 fd, Str in, off_t offset)
     {
-        if (auto node = m_handles.find(fd, data::OpenMode::Write); node) {
+        if (auto node = m_handles.find(fd, OpenMode::Write); node) {
             co_return co_await node->write(make_context({}), fd, in, offset);
         }
         co_return Unexpect{ Errc::bad_file_descriptor };
@@ -547,7 +547,7 @@ namespace madbfs
             co_return Unexpect{ copied.error() };
         }
 
-        co_return (co_await m_connection.stat(out_path)).and_then([&](data::Stat new_stat) {
+        co_return (co_await m_connection.stat(out_path)).and_then([&](Stat new_stat) {
             node->get().set_stat(new_stat);
             return copied;
         });

--- a/madbfs/src/filesystem.cpp
+++ b/madbfs/src/filesystem.cpp
@@ -6,6 +6,10 @@
 #include <madbfs-common/log.hpp>
 
 #include <fmt/std.h>
+#include <sys/stat.h>
+
+constexpr auto timespec_now  = timespec{ .tv_sec = 0, .tv_nsec = UTIME_NOW };
+constexpr auto timespec_omit = timespec{ .tv_sec = 0, .tv_nsec = UTIME_OMIT };
 
 namespace madbfs
 {
@@ -165,7 +169,7 @@ namespace madbfs
         }
 
         // no change
-        if (old_stat and not detect_modification(old_stat->get(), *new_stat)) {
+        if (not node.as_error() and not detect_modification(old_stat, *new_stat)) {
             log_d(__func__, "unchanged: {:?}", path);
             node.expires_after(m_ttl.value_or(Seconds::max()));
             co_return Expect<void>{};
@@ -180,7 +184,7 @@ namespace madbfs
             node.expires_after(m_ttl.value_or(Seconds::max()));
         } break;
         case S_IFDIR: {
-            if (S_ISDIR(old_stat->get().mode)) {    // previously directory
+            if (S_ISDIR(old_stat.mode)) {    // previously directory
                 node.set_stat(*new_stat);
                 node.set_synced(false);    // don't mutate, force rescan
                 node.expires_after(m_ttl.value_or(Seconds::max()));
@@ -209,24 +213,6 @@ namespace madbfs
         co_return Expect<void>{};
     }
 
-    void Filesystem::walk(Node& start, std::function<void(Node&)> func)
-    {
-        auto stack = Vec<Node*>{ &start };
-
-        while (not stack.empty()) {
-            auto node = stack.back();
-            stack.pop_back();
-
-            func(*node);
-
-            if (auto list = node->list(); list) {
-                for (const auto& node : list->get()) {
-                    stack.push_back(node.get());
-                }
-            }
-        }
-    }
-
     Await<void> Filesystem::mutate_and_invalidate(Node& node, File file)
     {
         auto old = node.mutate(std::move(file));
@@ -246,25 +232,44 @@ namespace madbfs
         }
     }
 
+    void Filesystem::walk(Node& start, std::function<void(Node&)> func)
+    {
+        auto stack = Vec<Node*>{ &start };
+
+        while (not stack.empty()) {
+            auto node = stack.back();
+            stack.pop_back();
+
+            func(*node);
+
+            if (auto dir = node->as<node::Directory>(); dir) {
+                for (const auto& node : dir->get().children()) {
+                    stack.push_back(node.get());
+                }
+            }
+        }
+    }
+
     AExpect<void> Filesystem::readdir(path::Path path, Filler filler)
     {
-        auto parent = &m_root;
+        auto current = &m_root;
 
         if (not path.is_root()) {
             auto maybe_node = co_await traverse_or_build(path);
             if (not maybe_node.has_value()) {
                 co_return Unexpect{ maybe_node.error() };
             }
-            parent = &maybe_node->get();
+            current = &maybe_node->get();
         }
 
-        auto may_list = parent->list();
-        if (not may_list) {
-            co_return Unexpect{ may_list.error() };
+        auto current_dir = current->as<node::Directory>();
+        if (not current_dir) {
+            co_return Unexpect{ current_dir.error() };
         }
-        auto& list = may_list->get();
 
-        auto pathbuf    = path.extend_copy("dummy").value();
+        auto& list    = current_dir->get().children();
+        auto  pathbuf = path.extend_copy("dummy").value();
+
         auto build_file = [&](Str name, mode_t mode) -> Await<File> {
             auto renamed = pathbuf.rename(name);
             assert(renamed);
@@ -283,7 +288,7 @@ namespace madbfs
             }
         };
 
-        if (not parent->has_synced()) {
+        if (not current->has_synced()) {
             auto may_stats = co_await m_connection.statdir(path);
             if (not may_stats) {
                 co_return Unexpect{ may_stats.error() };
@@ -291,10 +296,10 @@ namespace madbfs
 
             if (list.empty()) {
                 for (auto [stat, name] : may_stats.value()) {
-                    log_d(__func__, "[{:?}] new entry    : {:?}", parent->name(), name);
+                    log_d(__func__, "[{:?}] new entry    : {:?}", current->name(), name);
 
                     auto file  = co_await build_file(name, stat.mode);
-                    auto child = std::make_unique<Node>(name, parent, std::move(stat), std::move(file));
+                    auto child = std::make_unique<Node>(name, current, std::move(stat), std::move(file));
                     child->expires_after(m_ttl.value_or(Seconds::max()));
                     list.emplace(std::move(child));
                 }
@@ -307,10 +312,10 @@ namespace madbfs
 
                     auto found = list.find(name);
                     if (found == list.end()) {
-                        log_d(__func__, "[{:?}] new entry: {:?}", parent->name(), name);
+                        log_d(__func__, "[{:?}] new entry: {:?}", current->name(), name);
 
                         auto file  = co_await build_file(name, stat.mode);
-                        auto child = std::make_unique<Node>(name, parent, std::move(stat), std::move(file));
+                        auto child = std::make_unique<Node>(name, current, std::move(stat), std::move(file));
                         child->expires_after(m_ttl.value_or(Seconds::max()));
                         list.emplace(std::move(child));
 
@@ -318,15 +323,15 @@ namespace madbfs
                     }
 
                     auto& child = (**found);
-                    if (auto child_stat = child.stat(); not child_stat) {    // Error node
-                        log_d(__func__, "[{:?}]   changed: {:?}", parent->name(), name);
+                    if (child.as_error()) {    // Error node
+                        log_d(__func__, "[{:?}]   changed: {:?}", current->name(), name);
 
                         auto file = co_await build_file(name, stat.mode);
                         child.set_stat(std::move(stat));
                         co_await mutate_and_invalidate(child, std::move(file));
                         child.expires_after(m_ttl.value_or(Seconds::max()));
-                    } else if (child.expired() and detect_modification(child_stat->get(), stat)) {
-                        log_d(__func__, "[{:?}]   changed: {:?}", parent->name(), name);
+                    } else if (child.expired() and detect_modification(child.stat(), stat)) {
+                        log_d(__func__, "[{:?}]   changed: {:?}", current->name(), name);
 
                         auto file = co_await build_file(name, stat.mode);
                         child.set_stat(std::move(stat));
@@ -334,14 +339,14 @@ namespace madbfs
                         child.expires_after(m_ttl.value_or(Seconds::max()));
                     }
 
-                    log_d(__func__, "[{:?}] unchanged: {:?}", parent->name(), name);
+                    log_d(__func__, "[{:?}] unchanged: {:?}", current->name(), name);
                 }
 
                 // remove old entries if doesn't exist in new entries
                 for (auto it = list.begin(); it != list.end();) {
                     auto name = (**it).name();
                     if (not new_list.contains(name)) {
-                        log_d(__func__, "[{:?}]   removed: {:?}", parent->name(), name);
+                        log_d(__func__, "[{:?}]   removed: {:?}", current->name(), name);
                         co_await m_cache.invalidate_one((**it).id(), false);    // should I flush
                         it = list.erase(it);
                         continue;
@@ -350,7 +355,7 @@ namespace madbfs
                 }
             }
 
-            parent->set_synced(true);
+            current->set_synced(true);
         }
 
         for (const auto& node : std::as_const(list)) {
@@ -364,58 +369,147 @@ namespace madbfs
 
     AExpect<NamedStat> Filesystem::getattr(path::Path path)
     {
-        co_return (co_await traverse_or_build(path)).and_then([](Node& node) {
-            return node.stat().transform([id = node.id()](const Stat& stat) {
-                return NamedStat{ .id = id, .stat = stat };
-            });
+        co_return (co_await traverse_or_build(path)).and_then([](Node& node) -> Expect<NamedStat> {
+            if (auto err = node.as_error(); err) {
+                return Unexpect{ err->error };
+            }
+            return NamedStat{ .id = node.id(), .stat = node.stat() };
         });
     }
 
     AExpect<Str> Filesystem::readlink(path::Path path)
     {
-        co_return (co_await traverse_or_build(path)).and_then(&Node::readlink);
+        co_return (co_await traverse_or_build(path))
+            .and_then([](Node& node) { return node.as<node::Link>(true); })
+            .transform([](node::Link& link) { return link.target; });
     }
 
     AExpect<Ref<Node>> Filesystem::mknod(path::Path path, mode_t mode, dev_t dev)
     {
-        auto parent = path.parent_path();
-        auto node   = co_await traverse_or_build(parent);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        auto parent  = co_await traverse_or_build(path.parent_path());
+        auto may_dir = parent.and_then(&Node::directory_prelude);
+
+        if (not may_dir) {
+            co_return Unexpect{ may_dir.error() };
         }
-        co_return co_await node->get().mknod(make_context(path), mode, dev);
+
+        auto& dir       = may_dir->get();
+        auto  name      = path.filename();
+        auto  overwrite = false;
+
+        if (auto node = dir.find(name); node) {
+            if (not node->get().is<node::Error>()) {
+                co_return Unexpect{ Errc::file_exists };
+            }
+            overwrite = true;
+        }
+
+        if (auto created = co_await m_connection.mknod(path, mode, dev); not created) {
+            co_return Unexpect{ created.error() };
+        }
+
+        co_return (co_await m_connection.stat(path))
+            .and_then([&](Stat stat) {
+                auto node = std::make_unique<Node>(name, &parent->get(), std::move(stat), node::Regular{});
+                return dir.insert(std::move(node), overwrite);
+            })
+            .transform([&](auto&& pair) { return pair.first; });
     }
 
     AExpect<Ref<Node>> Filesystem::mkdir(path::Path path, mode_t mode)
     {
-        auto parent = path.parent_path();
-        auto node   = co_await traverse_or_build(parent);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        auto parent  = co_await traverse_or_build(path.parent_path());
+        auto may_dir = parent.and_then(&Node::directory_prelude);
+
+        if (not may_dir) {
+            co_return Unexpect{ may_dir.error() };
         }
-        co_return co_await node->get().mkdir(make_context(path), mode);
+
+        auto& dir       = may_dir->get();
+        auto  name      = path.filename();
+        auto  overwrite = false;
+
+        if (auto node = dir.find(name); node) {
+            if (not node->get().is<node::Error>()) {
+                co_return Unexpect{ Errc::file_exists };
+            }
+            overwrite = true;
+        }
+
+        if (auto created = co_await m_connection.mkdir(path, mode); not created) {
+            co_return Unexpect{ created.error() };
+        }
+
+        co_return (co_await m_connection.stat(path))
+            .and_then([&](Stat stat) {
+                auto node = std::make_unique<Node>(name, &parent->get(), std::move(stat), node::Directory{});
+                return dir.insert(std::move(node), overwrite);
+            })
+            .transform([&](auto&& pair) { return pair.first; });
     }
 
     AExpect<void> Filesystem::unlink(path::Path path)
     {
-        auto parent = path.parent_path();
-        auto node   = co_await traverse_or_build(parent);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        auto parent  = co_await traverse_or_build(path.parent_path());    // what if path is not traversed yet
+        auto may_dir = parent.and_then(&Node::directory_prelude);
+
+        if (not may_dir) {
+            co_return Unexpect{ may_dir.error() };
         }
-        co_return (co_await node->get().unlink(make_context(path))).transform([&](Uniq<Node> node) {
-            m_handles.erase(node.get());
+
+        auto& dir  = may_dir->get();
+        auto  name = path.filename();
+
+        auto erased = dir.find(name).and_then([&](Node& node) -> Expect<Uniq<Node>> {
+            if (node.is<node::Directory>()) {
+                return Unexpect{ Errc::is_a_directory };
+            }
+            auto erased = dir.erase(name);
+            assert(erased.has_value());
+            return std::move(erased).value();
         });
+
+        if (not erased) {
+            co_return Unexpect{ erased.error() };
+        }
+
+        if (auto res = co_await m_connection.unlink(path); not res) {
+            auto overwritten = dir.insert(std::move(*erased), true);    // re-insert on failure :P
+            assert(not overwritten.has_value());
+            co_return Unexpect{ res.error() };
+        }
+
+        m_handles.erase(erased->get());
+        co_await m_cache.invalidate_one((*erased)->id(), false);
+
+        co_return Expect<void>{};
     }
 
     AExpect<void> Filesystem::rmdir(path::Path path)
     {
-        auto parent = path.parent_path();
-        auto node   = co_await traverse_or_build(parent);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        auto parent  = co_await traverse_or_build(path.parent_path());    // what if path is not traversed yet
+        auto may_dir = parent.and_then(&Node::directory_prelude);
+
+        if (not may_dir) {
+            co_return Unexpect{ may_dir.error() };
         }
-        co_return co_await node->get().rmdir(make_context(path));
+
+        auto& dir  = may_dir->get();
+        auto  name = path.filename();
+
+        auto target = dir.find(name).and_then([](Node& target) { return target.as<node::Directory>(true); });
+        if (not target) {
+            co_return Unexpect{ target.error() };
+        }
+
+        // disallow erasing if all the children is not Error
+        if (const auto& children = target->get().children(); not children.empty()) {
+            if (not sr::all_of(children, [](const Uniq<Node>& node) { return node->is<node::Error>(); })) {
+                co_return Unexpect{ Errc::directory_not_empty };
+            }
+        }
+
+        co_return (co_await m_connection.rmdir(path)).transform([&] { dir.erase(name); });
     }
 
     AExpect<void> Filesystem::rename(path::Path from, path::Path to, u32 flags)
@@ -430,9 +524,13 @@ namespace madbfs
             co_return Unexpect{ from_node.error() };
         }
 
+        auto  from_parent = from_node->get().parent();
+        auto& from_dir    = from_parent->as<node::Directory>()->get();    // guarantee to be directory
+
         auto to_parent = co_await traverse_or_build(to.parent_path());
-        if (not to_parent.has_value()) {
-            co_return Unexpect{ to_parent.error() };
+        auto to_dir    = to_parent.and_then([](Node& node) { return node.directory_prelude(); });
+        if (not to_dir) {
+            co_return Unexpect{ to_dir.error() };
         }
 
         if ((flags & RENAME_EXCHANGE) != 0) {
@@ -454,23 +552,22 @@ namespace madbfs
             co_return Unexpect{ res.error() };
         }
 
-        auto node = from_node->get().parent()->extract(from.filename()).value();
+        auto node = from_dir.extract(from.filename()).value();
         co_await m_cache.rename(node->id(), to);
 
         node->set_name(to.filename());
         node->set_parent(&to_parent->get());
-        auto overwritten = to_parent->get().insert(std::move(node), true).value();
+        auto overwritten = to_dir->get().insert(std::move(node), true).value();
 
         if ((flags & RENAME_EXCHANGE) != 0) {
             assert(overwritten.second != nullptr);
-            auto parent = from_node->get().parent();
-            auto node   = std::move(overwritten).second;
+            auto node = std::move(overwritten).second;
 
             co_await m_cache.rename(node->id(), from);
             node->set_name(from.filename());
-            node->set_parent(parent);
+            node->set_parent(from_parent);
 
-            auto res = parent->insert(std::move(node), false);
+            auto res = from_dir.insert(std::move(node), false);
             assert(res->second == nullptr);    // has extracted before
         } else if (overwritten.second != nullptr) {
             co_await m_cache.invalidate_one(overwritten.second->id(), false);
@@ -486,63 +583,151 @@ namespace madbfs
         if (not node) {
             co_return Unexpect{ node.error() };
         }
-        co_return co_await node->get().utimens(make_context(path), atime, mtime);
+        if (auto res = co_await m_connection.utimens(path, atime, mtime); not res) {
+            co_return Unexpect{ res.error() };
+        }
+        co_return (co_await m_connection.stat(path)).transform([&](Stat stat) {
+            node->get().set_stat(std::move(stat));
+        });
     }
 
     AExpect<void> Filesystem::truncate(path::Path path, off_t size)
     {
-        auto node = co_await traverse_or_build(path);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        auto may_node = co_await traverse_or_build(path);
+        auto may_file = may_node.and_then([](Node& node) { return node.regular_file_prelude(); });
+
+        if (not may_file) {
+            co_return Unexpect{ may_file.error() };
         }
-        co_return co_await node->get().truncate(make_context(path), size);
+
+        if (auto res = co_await m_connection.truncate(path, size); not res) {
+            co_return Unexpect{ res.error() };
+        }
+
+        auto& node = may_node->get();
+
+        auto old_size = static_cast<usize>(node.stat().size);
+        auto new_size = static_cast<usize>(size);
+
+        // error from Cache::truncate are from eviction only, which should not matter for this file
+        std::ignore = co_await m_cache.truncate(node.id(), old_size, new_size);
+
+        node.set_size(size);
+        node.refresh_stat(timespec_omit, timespec_now);
+
+        co_return Expect<void>{};
     }
 
     AExpect<u64> Filesystem::open(path::Path path, int flags)
     {
-        auto node = co_await traverse_or_build(path);
-        if (not node) {
-            co_return Unexpect{ node.error() };
+        auto may_node = co_await traverse_or_build(path);
+        auto may_file = may_node.and_then([](Node& node) { return node.regular_file_prelude(); });
+
+        if (not may_file) {
+            co_return Unexpect{ may_file.error() };
         }
-        auto mode = static_cast<OpenMode>(O_ACCMODE & flags);
-        co_return (co_await node->get().open(make_context(path), mode)).transform([&] {
-            return m_handles.store(&node->get(), mode);
+
+        auto& node = may_node->get();
+        auto  mode = static_cast<OpenMode>(O_ACCMODE & flags);
+
+        // send hint to cache to prepare a real fd that can be used for further operations
+        co_return (co_await m_cache.hint_open(node.id(), path, mode)).transform([&] {
+            return m_handles.store(&node, mode);
         });
     }
 
     AExpect<usize> Filesystem::read(u64 fd, Span<char> out, off_t offset)
     {
-        if (auto node = m_handles.find(fd, OpenMode::Read); node) {
-            co_return co_await node->read(make_context({}), fd, out, offset);
+        auto node = m_handles.find(fd, OpenMode::Read);
+        if (not node) {
+            co_return Unexpect{ Errc::bad_file_descriptor };
         }
-        co_return Unexpect{ Errc::bad_file_descriptor };
+
+        co_return (co_await m_cache.read(node->id(), out, offset)).transform([&](usize ret) {
+            node->refresh_stat(timespec_now, timespec_omit);
+            return ret;
+        });
     }
 
     AExpect<usize> Filesystem::write(u64 fd, Str in, off_t offset)
     {
-        if (auto node = m_handles.find(fd, OpenMode::Write); node) {
-            co_return co_await node->write(make_context({}), fd, in, offset);
+        auto node = m_handles.find(fd, OpenMode::Write);
+        if (not node) {
+            co_return Unexpect{ Errc::bad_file_descriptor };
         }
-        co_return Unexpect{ Errc::bad_file_descriptor };
+
+        auto may_file = node->regular_file_prelude();
+        if (not may_file) [[unlikely]] {
+            co_return Unexpect{ Errc::bad_file_descriptor };
+        }
+
+        auto& file = may_file->get();
+
+        co_return (co_await m_cache.write(node->id(), in, offset)).transform([&](usize ret) {
+            // the file size is defined as offset + size from last write if it's higher than previous size
+            auto new_size = offset + static_cast<off_t>(ret);
+            auto size     = std::max(node->stat().size, new_size);
+
+            node->set_size(size);
+            node->refresh_stat(timespec_omit, timespec_now);
+
+            file.dirty = true;
+
+            return ret;
+        });
     }
 
     AExpect<void> Filesystem::flush(u64 fd)
     {
-        if (auto [node, _] = m_handles.find(fd); node) {
-            co_return co_await node->flush(make_context({}));
+        auto [node, _] = m_handles.find(fd);
+        if (not node) {
+            co_return Unexpect{ Errc::bad_file_descriptor };
         }
-        co_return Unexpect{ Errc::bad_file_descriptor };
+
+        auto may_file = node->regular_file_prelude();
+        if (not may_file) [[unlikely]] {
+            co_return Unexpect{ Errc::bad_file_descriptor };
+        }
+
+        auto& file = may_file->get();
+        if (not file.dirty) {
+            co_return Expect<void>{};    // no writes, do nothing
+        }
+
+        co_return (co_await m_cache.flush(node->id())).transform([&] {
+            node->refresh_stat(timespec_omit, timespec_now);
+            file.dirty = false;
+        });
     }
 
     AExpect<void> Filesystem::release(u64 fd)
     {
-        if (auto [node, mode] = m_handles.release(fd); node) {
-            co_return (co_await node->release(make_context({}), mode)).transform_error([&](Errc err) {
-                m_handles.store(node, mode);    // if fail, do I need to store it again?
-                return err;
-            });
+        auto [node, mode] = m_handles.release(fd);
+        if (not node) {
+            co_return Unexpect{ Errc::bad_file_descriptor };
         }
-        co_return Unexpect{ Errc::bad_file_descriptor };
+
+        auto may_file = node->regular_file_prelude();
+        if (not may_file) [[unlikely]] {
+            co_return Unexpect{ Errc::bad_file_descriptor };
+        }
+
+        auto& file = may_file->get();
+        if (file.dirty) {
+            if (auto res = co_await m_cache.flush(node->id()); not res) {
+                co_return Unexpect{ res.error() };
+            }
+
+            node->refresh_stat(timespec_omit, timespec_now);
+            file.dirty = false;
+        }
+
+        // send hint to cache to close its associated fd for this node if exist
+        if (auto res = co_await m_cache.hint_close(node->id(), mode); not res) {
+            co_return Unexpect{ res.error() };
+        }
+
+        co_return Expect<void>{};
     }
 
     AExpect<usize> Filesystem::copy_file_range(
@@ -577,9 +762,46 @@ namespace madbfs
 
     Expect<void> Filesystem::symlink(path::Path path, Str target)
     {
-        return traverse(path.parent_path())
-            .and_then(proj(&Node::symlink, path.filename(), target))
-            .transform(sink_void);
+        auto parent  = traverse(path.parent_path());
+        auto may_dir = parent.and_then(&Node::directory_prelude);
+
+        if (not may_dir) {
+            return Unexpect{ may_dir.error() };
+        }
+
+        auto& dir  = may_dir->get();
+        auto  name = path.filename();
+
+        if (dir.find(name)) {
+            return Unexpect{ Errc::file_exists };
+        }
+
+        // NOTE: we can't really make a symlink on android from adb (unless rooted device iirc), so this
+        // operation actually not creating any link on the adb device, just on the in-memory filetree.
+
+        auto now  = SystemClock::now().time_since_epoch();
+        auto sec  = std::chrono::duration_cast<Seconds>(now);
+        auto nsec = std::chrono::duration_cast<Nanoseconds>(now - sec);
+
+        auto time = timespec{ .tv_sec = sec.count(), .tv_nsec = nsec.count() };
+
+        // dummy stat for symlink based on
+        // lrw-r--r--  root root 21 2024-10-05 09:19:29.000000000 +0700 /sdcard -> /storage/self/primary
+        auto stat = Stat{
+            .links = 1,
+            .size  = 21,
+            .mtime = time,
+            .atime = time,
+            .ctime = time,
+            .mode  = S_IFLNK | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH,    // mode: "lrw-r--r--"
+            .uid   = 0,
+            .gid   = 0,
+        };
+
+        auto link = node::Link{ String{ target } };
+        auto node = std::make_unique<Node>(name, &parent->get(), std::move(stat), std::move(link));
+
+        return dir.insert(std::move(node), false).transform(sink_void);
     }
 
     Await<void> Filesystem::shutdown()

--- a/madbfs/src/filesystem.cpp
+++ b/madbfs/src/filesystem.cpp
@@ -158,7 +158,7 @@ namespace madbfs
         if (not new_stat) {
             auto err = new_stat.error();
             if (err != Errc::not_connected and err != Errc::timed_out) {
-                node.mutate(node::Error{ err });
+                co_await mutate_and_invalidate(node, node::Error{ err });
                 node.expires_after(m_ttl.value_or(Seconds::max()));
             }
             co_return Unexpect{ err };
@@ -172,36 +172,36 @@ namespace madbfs
         }
 
         log_w(__func__, "  changed: {:?}", path);
-        co_await m_cache.invalidate_one(node.id(), false);    // maybe conditionally flush?
 
         switch (new_stat->mode & S_IFMT) {
         case S_IFREG: {
-            // TODO: if the file type is unchanged but the data is changed, we need to choose whether to
-            // prioritize data from the host or the remote. maybe add a policy on the VFS itself so the user
-            // can choose what suits them best.
             node.set_stat(*new_stat);
-            node.mutate(node::Regular{});
+            co_await mutate_and_invalidate(node, node::Regular{});    // invalidate currently held data
             node.expires_after(m_ttl.value_or(Seconds::max()));
         } break;
         case S_IFDIR: {
-            if (S_ISDIR(old_stat->get().mode)) {
+            if (S_ISDIR(old_stat->get().mode)) {    // previously directory
                 node.set_stat(*new_stat);
-                node.set_synced(false);
+                node.set_synced(false);    // don't mutate, force rescan
+                node.expires_after(m_ttl.value_or(Seconds::max()));
+            } else {
+                node.set_stat(*new_stat);
+                co_await mutate_and_invalidate(node, node::Directory{});    // not directory, becomes one
                 node.expires_after(m_ttl.value_or(Seconds::max()));
             }
         } break;
         case S_IFLNK: {
             if (auto target = co_await m_connection.readlink(path); target) {
                 node.set_stat(*new_stat);
-                node.mutate(node::Link{ std::move(target).value() });
+                co_await mutate_and_invalidate(node, node::Link{ std::move(target).value() });
             } else {
-                node.mutate(node::Error{ target.error() });
+                co_await mutate_and_invalidate(node, node::Error{ target.error() });
             }
             node.expires_after(m_ttl.value_or(Seconds::max()));
         } break;
         default: {
             node.set_stat(*new_stat);
-            node.mutate(node::Other{});
+            co_await mutate_and_invalidate(node, node::Other{});
             node.expires_after(m_ttl.value_or(Seconds::max()));
         } break;
         }
@@ -209,9 +209,9 @@ namespace madbfs
         co_return Expect<void>{};
     }
 
-    void Filesystem::walk(std::function<void(Node&)> func)
+    void Filesystem::walk(Node& start, std::function<void(Node&)> func)
     {
-        auto stack = Vec<Node*>{ &m_root };
+        auto stack = Vec<Node*>{ &start };
 
         while (not stack.empty()) {
             auto node = stack.back();
@@ -224,6 +224,25 @@ namespace madbfs
                     stack.push_back(node.get());
                 }
             }
+        }
+    }
+
+    Await<void> Filesystem::mutate_and_invalidate(Node& node, File file)
+    {
+        auto old = node.mutate(std::move(file));
+
+        if (auto dir = std::get_if<node::Directory>(&old)) {
+            auto nodes = std::vector<Node*>{};
+            for (const auto& node : dir->children()) {
+                walk(*node, [&](Node& n) { m_handles.erase(&n), nodes.push_back(&n); });
+            }
+            for (auto node : nodes) {
+                co_await m_cache.invalidate_one(node->id(), false);    // maybe flush? child might not change
+            }
+            m_handles.erase(&node);
+        } else if (std::get_if<node::Regular>(&old)) {
+            co_await m_cache.invalidate_one(node.id(), false);    // no flush needed since the file changed
+            m_handles.erase(&node);
         }
     }
 
@@ -302,17 +321,17 @@ namespace madbfs
                     if (auto child_stat = child.stat(); not child_stat) {    // Error node
                         log_d(__func__, "[{:?}]   changed: {:?}", parent->name(), name);
 
+                        auto file = co_await build_file(name, stat.mode);
                         child.set_stat(std::move(stat));
-                        child.mutate(co_await build_file(name, stat.mode));
+                        co_await mutate_and_invalidate(child, std::move(file));
                         child.expires_after(m_ttl.value_or(Seconds::max()));
                     } else if (child.expired() and detect_modification(child_stat->get(), stat)) {
                         log_d(__func__, "[{:?}]   changed: {:?}", parent->name(), name);
 
+                        auto file = co_await build_file(name, stat.mode);
                         child.set_stat(std::move(stat));
-                        child.mutate(co_await build_file(name, stat.mode));
+                        co_await mutate_and_invalidate(child, std::move(file));
                         child.expires_after(m_ttl.value_or(Seconds::max()));
-
-                        co_await m_cache.invalidate_one(child.id(), false);    // should I flush?
                     }
 
                     log_d(__func__, "[{:?}] unchanged: {:?}", parent->name(), name);
@@ -384,7 +403,9 @@ namespace madbfs
         if (not node) {
             co_return Unexpect{ node.error() };
         }
-        co_return co_await node->get().unlink(make_context(path));
+        co_return (co_await node->get().unlink(make_context(path))).transform([&](Uniq<Node> node) {
+            m_handles.erase(node.get());
+        });
     }
 
     AExpect<void> Filesystem::rmdir(path::Path path)
@@ -453,6 +474,7 @@ namespace madbfs
             assert(res->second == nullptr);    // has extracted before
         } else if (overwritten.second != nullptr) {
             co_await m_cache.invalidate_one(overwritten.second->id(), false);
+            m_handles.erase(overwritten.second.get());
         }
 
         co_return Expect<void>{};
@@ -576,7 +598,7 @@ namespace madbfs
         // on change from ttl on to ttl off, sets all nodes expiration to never
 
         log_i(__func__, "ttl changed [{} -> {}] resetting expirations", old, ttl);
-        walk([=](Node& node) { node.expires_after(ttl.value_or(Seconds::max())); });
+        walk(m_root, [=](Node& node) { node.expires_after(ttl.value_or(Seconds::max())); });
 
         return old;
     }
@@ -584,7 +606,7 @@ namespace madbfs
     usize Filesystem::expires_all()
     {
         auto count = 0uz;
-        walk([&](Node& node) { ++count, node.expires_after(Seconds{ 0 }); });
+        walk(m_root, [&](Node& node) { ++count, node.expires_after(Seconds{ 0 }); });
         return count;
     }
 }

--- a/madbfs/src/filesystem.cpp
+++ b/madbfs/src/filesystem.cpp
@@ -381,7 +381,7 @@ namespace madbfs
     {
         co_return (co_await traverse_or_build(path))
             .and_then([](Node& node) { return node.as<node::Link>(true); })
-            .transform([](node::Link& link) { return link.target; });
+            .transform([](node::Link& link) { return Str{ link.target }; });
     }
 
     AExpect<Ref<Node>> Filesystem::mknod(path::Path path, mode_t mode, dev_t dev)

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -23,10 +23,10 @@ namespace madbfs
     {
         Await<json::value> handle(ipc::op::Info)
         {
-            const auto page_size     = madbfs.m_cache.page_size();
-            const auto max_pages     = madbfs.m_cache.max_pages();
-            const auto current_pages = madbfs.m_cache.current_pages();
-            const auto ttl_sec       = madbfs.m_tree.ttl().transform(&Seconds::count);
+            const auto page_size     = madbfs.fs().cache().page_size();
+            const auto max_pages     = madbfs.fs().cache().max_pages();
+            const auto current_pages = madbfs.fs().cache().current_pages();
+            const auto ttl_sec       = madbfs.fs().ttl().transform(&Seconds::count);
             const auto timeout_sec   = madbfs.m_timeout.transform(&Seconds::count);
 
             co_return json::value{
@@ -43,24 +43,24 @@ namespace madbfs
 
         Await<json::value> handle(ipc::op::InvalidateCache)
         {
-            const auto page_size     = madbfs.m_cache.page_size();
-            const auto current_pages = madbfs.m_cache.current_pages();
+            const auto page_size     = madbfs.fs().cache().page_size();
+            const auto current_pages = madbfs.fs().cache().current_pages();
 
-            co_await madbfs.m_cache.invalidate_all();
+            co_await madbfs.fs().cache().invalidate_all();
 
             co_return json::value{ { "size", page_size * current_pages / 1024 / 1024 } };
         }
 
         Await<json::value> handle(ipc::op::ExpireStat)
         {
-            auto count = madbfs.filesystem().expires_all();
+            auto count = madbfs.fs().expires_all();
             co_return json::value{ { "count", count } };
         }
 
         Await<json::value> handle(ipc::op::SetPageSize size)
         {
-            const auto old_size = madbfs.m_cache.page_size();
-            const auto old_max  = madbfs.m_cache.max_pages();
+            const auto old_size = madbfs.fs().cache().page_size();
+            const auto old_max  = madbfs.fs().cache().max_pages();
 
             auto new_size = std::bit_ceil(size.kib * 1024);
             new_size      = std::clamp(new_size, lowest_page_size, highest_page_size);
@@ -68,8 +68,8 @@ namespace madbfs
             auto new_max = std::bit_ceil(old_max * old_size / new_size);
             new_max      = std::max(new_max, lowest_max_pages);
 
-            co_await madbfs.m_cache.set_page_size(new_size);
-            co_await madbfs.m_cache.set_max_pages(new_max);
+            co_await madbfs.fs().cache().set_page_size(new_size);
+            co_await madbfs.fs().cache().set_max_pages(new_max);
 
             co_return json::value{
                 { "page_size",
@@ -83,13 +83,13 @@ namespace madbfs
 
         Await<json::value> handle(ipc::op::SetCacheSize size)
         {
-            const auto page    = madbfs.m_cache.page_size();
-            const auto old_max = madbfs.m_cache.max_pages();
+            const auto page    = madbfs.fs().cache().page_size();
+            const auto old_max = madbfs.fs().cache().max_pages();
 
             auto new_max = std::bit_ceil(size.mib * 1024 * 1024 / page);
             new_max      = std::max(new_max, lowest_max_pages);
 
-            co_await madbfs.m_cache.set_max_pages(new_max);
+            co_await madbfs.fs().cache().set_max_pages(new_max);
 
             co_return json::value{
                 { "cache_size",
@@ -101,7 +101,7 @@ namespace madbfs
         Await<json::value> handle(ipc::op::SetTTL ttl)
         {
             const auto new_ttl = ttl.sec < 1 ? std::nullopt : Opt<Seconds>{ ttl.sec };
-            const auto old_ttl = madbfs.m_tree.set_ttl(new_ttl);
+            const auto old_ttl = madbfs.fs().set_ttl(new_ttl);
 
             co_return json::value{
                 { "ttl",
@@ -216,8 +216,7 @@ namespace madbfs
         , m_work_guard{ m_async_ctx.get_executor() }
         , m_work_thread{ [this] { work_thread_function(m_async_ctx); } }
         , m_connection{ prepare_connection(m_async_ctx, connection) }
-        , m_cache{ m_connection, page_size, max_pages }
-        , m_tree{ m_connection, m_cache, ttl }
+        , m_fs{ m_connection, page_size, max_pages, ttl }
         , m_ipc{ create_ipc(m_async_ctx) }
         , m_watchdog_timer{ m_async_ctx }
         , m_reaper_timer{ m_async_ctx }
@@ -260,7 +259,7 @@ namespace madbfs
         m_watchdog_timer.cancel();
         m_reaper_timer.cancel();
 
-        async::block(m_async_ctx, m_cache.shutdown());
+        async::block(m_async_ctx, m_fs.shutdown());
         m_connection.cancel(Errc::operation_canceled);
 
         m_work_guard.reset();
@@ -291,13 +290,13 @@ namespace madbfs
             if (not ok) {
                 log_i(__func__, "connection is timed out");
                 if (auto res = co_await m_connection.reconnect(); res) {
-                    co_await m_cache.invalidate_fds(false);
+                    co_await m_fs.cache().invalidate_fds(false);
                     co_await m_connection.start();
                 }
             } else if (not m_connection.is_optimal()) {
                 log_i(__func__, "connection is ok but not optimized. trying to optimize...");
                 if (auto res = co_await m_connection.optimize(); res) {
-                    co_await m_cache.invalidate_fds(false);
+                    co_await m_fs.cache().invalidate_fds(false);
                     co_await m_connection.start();
                 }
             } else {
@@ -317,7 +316,15 @@ namespace madbfs
                 break;
             }
 
-            co_await m_cache.clean_stale_fds();
+            co_await m_fs.cache().clean_stale_fds();
+
+            const auto& handles = m_fs.handles();
+
+            auto cap   = handles.size();
+            auto pred  = [](auto&& v) { return std::get<0>(v) == nullptr; };
+            auto empty = static_cast<usize>(sr::count_if(handles.iter(), pred));
+
+            log_w(__func__, "file handles [cap={:>40d}|open={:>40d}|null={:>40d}]", cap, cap - empty, empty);
         }
     }
 }

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -53,7 +53,7 @@ namespace madbfs
 
         Await<json::value> handle(ipc::op::ExpireStat)
         {
-            auto count = madbfs.tree().expires_all();
+            auto count = madbfs.filesystem().expires_all();
             co_return json::value{ { "count", count } };
         }
 

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -324,7 +324,7 @@ namespace madbfs
             auto pred  = [](auto&& v) { return std::get<0>(v) == nullptr; };
             auto empty = static_cast<usize>(sr::count_if(handles.iter(), pred));
 
-            log_w(__func__, "file handles [cap={:>40d}|open={:>40d}|null={:>40d}]", cap, cap - empty, empty);
+            log_i(__func__, "file handles [cap={:>04d}|open={:>04d}|unused={:>04d}]", cap, cap - empty, empty);
         }
     }
 }

--- a/madbfs/src/node.cpp
+++ b/madbfs/src/node.cpp
@@ -4,33 +4,6 @@
 
 namespace madbfs::node
 {
-    Regular::Mode Regular::open(u64 fd, int flags)
-    {
-        assert(not is_open(fd));
-        auto mode = static_cast<Mode>(O_ACCMODE & flags);
-        m_open_fds.emplace_back(fd, mode);
-        return mode;
-    }
-
-    Opt<Regular::Mode> Regular::close(u64 fd)
-    {
-        if (auto entry = sr::find(m_open_fds, fd, &Entry::fd); entry != m_open_fds.end()) {
-            return m_open_fds.erase(entry)->mode;
-        }
-        return std::nullopt;
-    }
-
-    bool Regular::check(u64 fd, Mode mode) const
-    {
-        if (auto entry = sr::find(m_open_fds, fd, &Entry::fd); entry != m_open_fds.end()) {
-            return entry->mode == Mode::ReadWrite or entry->mode == mode;
-        }
-        return false;
-    }
-}
-
-namespace madbfs::node
-{
     u64 Directory::NodeHash::operator()(const Uniq<Node>& node) const
     {
         return (*this)(node->name());
@@ -115,7 +88,7 @@ namespace madbfs
     bool Node::expired() const
     {
         // prevent expiration if the file is dirty
-        if (auto file = as<node::Regular>(); file and file->get().is_dirty()) {
+        if (auto file = as<node::Regular>(); file and file->get().dirty) {
             return false;
         }
         return SteadyClock::now() > m_expiration;
@@ -423,37 +396,20 @@ namespace madbfs
         co_return Expect<void>{};
     }
 
-    AExpect<u64> Node::open(Context context, int flags)
+    AExpect<void> Node::open(Context context, data::OpenMode mode)
     {
-        auto may_file = regular_file_prelude();
-        if (not may_file) {
-            co_return Unexpect{ may_file.error() };
+        if (auto file = regular_file_prelude(); not file) {
+            co_return Unexpect{ file.error() };
         }
-        auto& file = may_file->get();
-
-        auto fd   = context.fd_counter.fetch_add(1, std::memory_order::relaxed) + 1;
-        auto mode = file.open(fd, flags);
 
         // send hint to cache to prepare a real fd that can be used for further operations
-        auto res = co_await context.cache.hint_open(id(), context.path, mode);
-        if (not res) {
-            file.close(fd);
-            co_return Unexpect{ res.error() };
-        }
-
-        co_return fd;
+        co_return co_await context.cache.hint_open(id(), context.path, mode);
     }
 
     AExpect<usize> Node::read(Context context, u64 fd, Span<char> out, off_t offset)
     {
-        auto may_file = regular_file_prelude();
-        if (not may_file) {
-            co_return Unexpect{ may_file.error() };
-        }
-        auto& file = may_file->get();
-
-        if (not file.check(fd, data::OpenMode::Read)) {
-            co_return Unexpect{ Errc::bad_file_descriptor };
+        if (auto file = regular_file_prelude(); not file) {
+            co_return Unexpect{ file.error() };
         }
 
         co_return (co_await context.cache.read(id(), out, offset)).transform([&](usize ret) {
@@ -464,17 +420,12 @@ namespace madbfs
 
     AExpect<usize> Node::write(Context context, u64 fd, Str in, off_t offset)
     {
-        auto may_file = regular_file_prelude();
-        if (not may_file) {
-            co_return Unexpect{ may_file.error() };
-        }
-        auto& file = may_file->get();
-
-        if (not file.check(fd, data::OpenMode::Write)) {
-            co_return Unexpect{ Errc::bad_file_descriptor };
+        if (auto file = regular_file_prelude(); not file) {
+            co_return Unexpect{ file.error() };
+        } else {
+            file->get().dirty = true;
         }
 
-        file.set_dirty(true);
         co_return (co_await context.cache.write(id(), in, offset)).transform([&](usize ret) {
             // the file size is defined as offset + size from last write if it's higher than previous size
             // NOTE: this may be different for sparse files but I don't think Android has it
@@ -485,51 +436,39 @@ namespace madbfs
         });
     }
 
-    AExpect<void> Node::flush(Context context, u64 fd)
+    AExpect<void> Node::flush(Context context)
     {
-        auto may_file = regular_file_prelude();
-        if (not may_file) {
-            co_return Unexpect{ may_file.error() };
-        }
-        auto& file = may_file->get();
-
-        if (not file.is_open(fd)) {
-            co_return Unexpect{ Errc::bad_file_descriptor };
-        }
-        if (not file.is_dirty()) {
+        auto file = regular_file_prelude();
+        if (not file) {
+            co_return Unexpect{ file.error() };
+        } else if (not file->get().dirty) {
             co_return Expect<void>{};    // no write, do nothing
         }
 
         co_return (co_await context.cache.flush(id())).transform([&] {
             refresh_stat(timespec_omit, timespec_now);
-            file.set_dirty(false);
+            file->get().dirty = false;
         });
     }
 
-    AExpect<void> Node::release(Context context, u64 fd)
+    AExpect<void> Node::release(Context context, data::OpenMode mode)
     {
-        auto may_file = regular_file_prelude();
-        if (not may_file) {
-            co_return Unexpect{ may_file.error() };
-        }
-        auto& file = may_file->get();
-
-        auto mode = file.close(fd);
-        if (not mode) {
-            co_return Unexpect{ Errc::bad_file_descriptor };
+        auto file = regular_file_prelude();
+        if (not file) {
+            co_return Unexpect{ file.error() };
         }
 
-        if (file.is_dirty()) {
+        if (file->get().dirty) {
             if (auto res = co_await context.cache.flush(id()); not res) {
                 co_return Unexpect{ res.error() };
             }
 
             refresh_stat(timespec_omit, timespec_now);
-            file.set_dirty(false);
+            file->get().dirty = false;
         }
 
         // send hint to cache to close its associated fd for this node if exist
-        if (auto res = co_await context.cache.hint_close(id(), *mode); not res) {
+        if (auto res = co_await context.cache.hint_close(id(), mode); not res) {
             co_return Unexpect{ res.error() };
         }
 

--- a/madbfs/src/node.cpp
+++ b/madbfs/src/node.cpp
@@ -1,8 +1,8 @@
-#include "madbfs/tree/node.hpp"
+#include "madbfs/node.hpp"
 
 #include "madbfs/connection.hpp"
 
-namespace madbfs::tree::node
+namespace madbfs::node
 {
     Regular::Mode Regular::open(u64 fd, int flags)
     {
@@ -29,7 +29,7 @@ namespace madbfs::tree::node
     }
 }
 
-namespace madbfs::tree::node
+namespace madbfs::node
 {
     u64 Directory::NodeHash::operator()(const Uniq<Node>& node) const
     {
@@ -93,7 +93,7 @@ namespace madbfs::tree::node
     }
 }
 
-namespace madbfs::tree
+namespace madbfs
 {
     Expect<Ref<const data::Stat>> Node::stat() const
     {

--- a/madbfs/src/node.cpp
+++ b/madbfs/src/node.cpp
@@ -68,7 +68,7 @@ namespace madbfs::node
 
 namespace madbfs
 {
-    Expect<Ref<const data::Stat>> Node::stat() const
+    Expect<Ref<const Stat>> Node::stat() const
     {
         if (auto err = as<node::Error>(); err.has_value()) {
             return Unexpect{ err->get().error };
@@ -174,7 +174,7 @@ namespace madbfs
             .transform([&](node::Directory& dir) { return std::ref(dir.children()); });
     }
 
-    Expect<Ref<Node>> Node::build(Str name, data::Stat stat, File file)
+    Expect<Ref<Node>> Node::build(Str name, Stat stat, File file)
     {
         if (auto err = as<node::Error>(); err.has_value()) {
             return Unexpect{ err->get().error };
@@ -225,7 +225,7 @@ namespace madbfs
 
             // dummy stat for symlink based on
             // lrw-r--r--  root root 21 2024-10-05 09:19:29.000000000 +0700 /sdcard -> /storage/self/primary
-            auto stat = data::Stat{
+            auto stat = Stat{
                 .links = 1,
                 .size  = 21,
                 .mtime = time,
@@ -268,7 +268,7 @@ namespace madbfs
         }
 
         co_return (co_await context.connection.stat(context.path))
-            .and_then([&](data::Stat stat) {
+            .and_then([&](Stat stat) {
                 auto node = std::make_unique<Node>(name, this, std::move(stat), node::Regular{});
                 return dir.insert(std::move(node), overwrite);
             })
@@ -303,7 +303,7 @@ namespace madbfs
         }
 
         co_return (co_await context.connection.stat(context.path))
-            .and_then([&](data::Stat stat) {
+            .and_then([&](Stat stat) {
                 auto node = std::make_unique<Node>(name, this, std::move(stat), node::Directory{});
                 return dir.insert(std::move(node), overwrite);
             })
@@ -396,7 +396,7 @@ namespace madbfs
         co_return Expect<void>{};
     }
 
-    AExpect<void> Node::open(Context context, data::OpenMode mode)
+    AExpect<void> Node::open(Context context, OpenMode mode)
     {
         if (auto file = regular_file_prelude(); not file) {
             co_return Unexpect{ file.error() };
@@ -451,7 +451,7 @@ namespace madbfs
         });
     }
 
-    AExpect<void> Node::release(Context context, data::OpenMode mode)
+    AExpect<void> Node::release(Context context, OpenMode mode)
     {
         auto file = regular_file_prelude();
         if (not file) {
@@ -480,7 +480,7 @@ namespace madbfs
         if (auto res = co_await context.connection.utimens(context.path, atime, mtime); not res) {
             co_return Unexpect{ res.error() };
         }
-        co_return (co_await context.connection.stat(context.path)).transform([&](data::Stat stat) {
+        co_return (co_await context.connection.stat(context.path)).transform([&](Stat stat) {
             m_stat = std::move(stat);
         });
     }

--- a/madbfs/src/node.cpp
+++ b/madbfs/src/node.cpp
@@ -32,13 +32,12 @@ namespace madbfs::node
         return Unexpect{ Errc::no_such_file_or_directory };
     }
 
-    bool Directory::erase(Str name)
+    Opt<Uniq<Node>> Directory::erase(Str name)
     {
         if (auto found = m_children.find(name); found != m_children.end()) {
-            m_children.erase(found);
-            return true;
+            return std::move(m_children.extract(found).value());
         }
-        return false;
+        return std::nullopt;
     }
 
     Expect<Pair<Ref<Node>, Uniq<Node>>> Directory::insert(Uniq<Node> node, bool overwrite)
@@ -310,26 +309,26 @@ namespace madbfs
             .transform([&](auto&& pair) { return pair.first; });
     }
 
-    AExpect<void> Node::unlink(Context context)
+    AExpect<Uniq<Node>> Node::unlink(Context context)
     {
         if (auto err = as<node::Error>(); err.has_value()) {
             co_return Unexpect{ err->get().error };
         }
 
-        auto res = as<node::Directory>().and_then([&](node::Directory& dir) -> Expect<void> {
+        auto erased = as<node::Directory>().and_then([&](node::Directory& dir) -> Expect<Uniq<Node>> {
             auto name = context.path.filename();
-            return dir.find(name).and_then([&](Node& node) -> Expect<void> {
+            return dir.find(name).and_then([&](Node& node) -> Expect<Uniq<Node>> {
                 if (node.is<node::Directory>()) {
                     return Unexpect{ Errc::is_a_directory };
                 }
-                auto success = dir.erase(name);
-                assert(success);
-                return {};
+                auto erased = dir.erase(name);
+                assert(erased.has_value());
+                return std::move(erased).value();
             });
         });
 
-        if (not res) {
-            co_return Unexpect{ res.error() };
+        if (not erased) {
+            co_return Unexpect{ erased.error() };
         }
 
         if (auto res = co_await context.connection.unlink(context.path); not res) {
@@ -337,7 +336,7 @@ namespace madbfs
         }
 
         co_await context.cache.invalidate_one(id(), false);
-        co_return Expect<void>{};
+        co_return erased;
     }
 
     AExpect<void> Node::rmdir(Context context)

--- a/madbfs/src/node.cpp
+++ b/madbfs/src/node.cpp
@@ -67,14 +67,6 @@ namespace madbfs::node
 
 namespace madbfs
 {
-    Expect<Ref<const Stat>> Node::stat() const
-    {
-        if (auto err = as<node::Error>(); err.has_value()) {
-            return Unexpect{ err->get().error };
-        }
-        return m_stat;
-    }
-
     void Node::expires_after(Seconds duration)
     {
         if (duration == Seconds::max()) {
@@ -164,15 +156,6 @@ namespace madbfs
         return as<node::Directory>().and_then(proj(&node::Directory::find, name));
     }
 
-    Expect<Ref<node::Directory::List>> Node::list()
-    {
-        if (auto err = as<node::Error>(); err.has_value()) {
-            return Unexpect{ err->get().error };
-        }
-        return as<node::Directory>()    //
-            .transform([&](node::Directory& dir) { return std::ref(dir.children()); });
-    }
-
     Expect<Ref<Node>> Node::build(Str name, Stat stat, File file)
     {
         if (auto err = as<node::Error>(); err.has_value()) {
@@ -187,309 +170,31 @@ namespace madbfs
             .transform([](auto&& pair) { return pair.first; });
     }
 
-    Expect<Uniq<Node>> Node::extract(Str name)
+    Expect<Ref<node::Regular>> Node::regular_file_prelude()
     {
-        if (auto err = as<node::Error>(); err.has_value()) {
-            return Unexpect{ err->get().error };
-        }
-        return as<node::Directory>().and_then(proj(&node::Directory::extract, name));
+        // NOTE: reading/writing special files (excluding symlink) is not possible by FUSE alone. One
+        // can present them by disguising it as regular files though.
+        //
+        // read: - https://github.com/rpodgorny/unionfs-fuse/issues/66
+        //       - https://github.com/libfuse/libfuse/issues/182
+
+        using Ret = Expect<Ref<node::Regular>>;
+
+        // clang-format off
+        auto overload = Overload{
+            [](node::Regular&   reg) -> Ret { return reg;                                             },
+            [](node::Directory&    ) -> Ret { return Unexpect{ Errc::is_a_directory };                },
+            [](node::Link&         ) -> Ret { return Unexpect{ Errc::too_many_symbolic_link_levels }; },  // mimick open(2) when no O_NOFOLLOW
+            [](node::Other&        ) -> Ret { return Unexpect{ Errc::operation_not_supported };       },
+            [](node::Error&     err) -> Ret { return Unexpect{ err.error };                           },
+        };
+        // clang-format on
+
+        return std::visit(overload, m_value);
     }
 
-    Expect<Pair<Ref<Node>, Uniq<Node>>> Node::insert(Uniq<Node> node, bool overwrite)
+    Expect<Ref<node::Directory>> Node::directory_prelude()
     {
-        if (auto err = as<node::Error>(); err.has_value()) {
-            return Unexpect{ err->get().error };
-        }
-        return as<node::Directory>().and_then(proj(&node::Directory::insert, std::move(node), overwrite));
-    }
-
-    Expect<Ref<Node>> Node::symlink(Str name, Str target)
-    {
-        if (auto err = as<node::Error>(); err.has_value()) {
-            return Unexpect{ err->get().error };
-        }
-        return as<node::Directory>().and_then([&](node::Directory& dir) -> Expect<Ref<Node>> {
-            if (dir.find(name).has_value()) {
-                return Unexpect{ Errc::file_exists };
-            }
-
-            // NOTE: we can't really make a symlink on android from adb (unless rooted device iirc), so this
-            // operation actually not creating any link on the adb device, just on the in-memory filetree.
-
-            auto now  = SystemClock::now().time_since_epoch();
-            auto sec  = std::chrono::duration_cast<Seconds>(now);
-            auto nsec = std::chrono::duration_cast<Nanoseconds>(now - sec);
-
-            auto time = timespec{ .tv_sec = sec.count(), .tv_nsec = nsec.count() };
-
-            // dummy stat for symlink based on
-            // lrw-r--r--  root root 21 2024-10-05 09:19:29.000000000 +0700 /sdcard -> /storage/self/primary
-            auto stat = Stat{
-                .links = 1,
-                .size  = 21,
-                .mtime = time,
-                .atime = time,
-                .ctime = time,
-                .mode  = S_IFLNK | S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH,    // mode: "lrw-r--r--"
-                .uid   = 0,
-                .gid   = 0,
-            };
-
-            auto node = std::make_unique<Node>(name, this, std::move(stat), node::Link{ String{ target } });
-            return dir.insert(std::move(node), false).transform([&](auto&& pair) { return pair.first; });
-        });
-    }
-
-    AExpect<Ref<Node>> Node::mknod(Context context, mode_t mode, dev_t dev)
-    {
-        if (auto err = as<node::Error>(); err.has_value()) {
-            co_return Unexpect{ err->get().error };
-        }
-
-        auto may_dir = as<node::Directory>();
-        if (not may_dir) {
-            co_return Unexpect{ may_dir.error() };
-        }
-
-        auto& dir  = may_dir->get();
-        auto  name = context.path.filename();
-
-        auto overwrite = false;
-        if (auto node = dir.find(name); node.has_value()) {
-            if (not node->get().is<node::Error>()) {
-                co_return Unexpect{ Errc::file_exists };
-            }
-            overwrite = true;
-        }
-
-        if (auto created = co_await context.connection.mknod(context.path, mode, dev); not created) {
-            co_return Unexpect{ created.error() };
-        }
-
-        co_return (co_await context.connection.stat(context.path))
-            .and_then([&](Stat stat) {
-                auto node = std::make_unique<Node>(name, this, std::move(stat), node::Regular{});
-                return dir.insert(std::move(node), overwrite);
-            })
-            .transform([&](auto&& pair) { return pair.first; });
-    }
-
-    AExpect<Ref<Node>> Node::mkdir(Context context, mode_t mode)
-    {
-        if (auto err = as<node::Error>(); err.has_value()) {
-            co_return Unexpect{ err->get().error };
-        }
-
-        auto may_dir = as<node::Directory>();
-        if (not may_dir) {
-            co_return Unexpect{ may_dir.error() };
-        }
-
-        auto& dir  = may_dir->get();
-        auto  name = context.path.filename();
-
-        auto overwrite = false;
-        if (auto node = dir.find(name); node.has_value()) {
-            if (not node->get().is<node::Error>()) {
-                co_return Unexpect{ Errc::file_exists };
-            }
-            overwrite = true;
-        }
-
-        auto may_mkdir = co_await context.connection.mkdir(context.path, mode);
-        if (not may_mkdir) {
-            co_return Unexpect{ may_mkdir.error() };
-        }
-
-        co_return (co_await context.connection.stat(context.path))
-            .and_then([&](Stat stat) {
-                auto node = std::make_unique<Node>(name, this, std::move(stat), node::Directory{});
-                return dir.insert(std::move(node), overwrite);
-            })
-            .transform([&](auto&& pair) { return pair.first; });
-    }
-
-    AExpect<Uniq<Node>> Node::unlink(Context context)
-    {
-        if (auto err = as<node::Error>(); err.has_value()) {
-            co_return Unexpect{ err->get().error };
-        }
-
-        auto erased = as<node::Directory>().and_then([&](node::Directory& dir) -> Expect<Uniq<Node>> {
-            auto name = context.path.filename();
-            return dir.find(name).and_then([&](Node& node) -> Expect<Uniq<Node>> {
-                if (node.is<node::Directory>()) {
-                    return Unexpect{ Errc::is_a_directory };
-                }
-                auto erased = dir.erase(name);
-                assert(erased.has_value());
-                return std::move(erased).value();
-            });
-        });
-
-        if (not erased) {
-            co_return Unexpect{ erased.error() };
-        }
-
-        if (auto res = co_await context.connection.unlink(context.path); not res) {
-            co_return Unexpect{ res.error() };
-        }
-
-        co_await context.cache.invalidate_one(id(), false);
-        co_return erased;
-    }
-
-    AExpect<void> Node::rmdir(Context context)
-    {
-        if (auto err = as<node::Error>(); err.has_value()) {
-            co_return Unexpect{ err->get().error };
-        }
-
-        auto name = context.path.filename();
-
-        auto res = as<node::Directory>().and_then([&](node::Directory& dir) {
-            return dir.find(name).and_then([&](Node& node) {
-                return node.as<node::Directory>().and_then(
-                    [&](node::Directory& target) -> Expect<Ref<node::Directory>> {
-                        if (not target.children().empty()) {
-                            for (const auto& child : target.children()) {
-                                if (not child->is<node::Error>()) {
-                                    Unexpect{ Errc::directory_not_empty };
-                                }
-                            }
-                        }
-                        return Expect<Ref<node::Directory>>{ dir };
-                    }
-                );
-            });
-        });
-
-        if (not res) {
-            co_return Unexpect{ res.error() };
-        }
-
-        co_return (co_await context.connection.rmdir(context.path)).transform([&] {
-            res->get().erase(name);
-        });
-    }
-
-    AExpect<void> Node::truncate(Context context, off_t size)
-    {
-        if (auto may_file = regular_file_prelude(); not may_file) {
-            co_return Unexpect{ may_file.error() };
-        }
-
-        if (auto res = co_await context.connection.truncate(context.path, size); not res) {
-            co_return Unexpect{ res.error() };
-        }
-
-        auto old_size = static_cast<usize>(m_stat.size);
-        auto new_size = static_cast<usize>(size);
-
-        // error from Cache::truncate are from eviction only, which should not matter for this file
-        std::ignore = co_await context.cache.truncate(id(), old_size, new_size);
-
-        m_stat.size = size;
-        refresh_stat({ .tv_sec = 0, .tv_nsec = UTIME_OMIT }, { .tv_sec = 0, .tv_nsec = UTIME_NOW });
-
-        co_return Expect<void>{};
-    }
-
-    AExpect<void> Node::open(Context context, OpenMode mode)
-    {
-        if (auto file = regular_file_prelude(); not file) {
-            co_return Unexpect{ file.error() };
-        }
-
-        // send hint to cache to prepare a real fd that can be used for further operations
-        co_return co_await context.cache.hint_open(id(), context.path, mode);
-    }
-
-    AExpect<usize> Node::read(Context context, u64 fd, Span<char> out, off_t offset)
-    {
-        if (auto file = regular_file_prelude(); not file) {
-            co_return Unexpect{ file.error() };
-        }
-
-        co_return (co_await context.cache.read(id(), out, offset)).transform([&](usize ret) {
-            refresh_stat(timespec_now, timespec_omit);
-            return ret;
-        });
-    }
-
-    AExpect<usize> Node::write(Context context, u64 fd, Str in, off_t offset)
-    {
-        if (auto file = regular_file_prelude(); not file) {
-            co_return Unexpect{ file.error() };
-        } else {
-            file->get().dirty = true;
-        }
-
-        co_return (co_await context.cache.write(id(), in, offset)).transform([&](usize ret) {
-            // the file size is defined as offset + size from last write if it's higher than previous size
-            // NOTE: this may be different for sparse files but I don't think Android has it
-            auto new_size = offset + static_cast<off_t>(ret);
-            m_stat.size   = std::max(m_stat.size, new_size);
-            refresh_stat(timespec_omit, timespec_now);
-            return ret;
-        });
-    }
-
-    AExpect<void> Node::flush(Context context)
-    {
-        auto file = regular_file_prelude();
-        if (not file) {
-            co_return Unexpect{ file.error() };
-        } else if (not file->get().dirty) {
-            co_return Expect<void>{};    // no write, do nothing
-        }
-
-        co_return (co_await context.cache.flush(id())).transform([&] {
-            refresh_stat(timespec_omit, timespec_now);
-            file->get().dirty = false;
-        });
-    }
-
-    AExpect<void> Node::release(Context context, OpenMode mode)
-    {
-        auto file = regular_file_prelude();
-        if (not file) {
-            co_return Unexpect{ file.error() };
-        }
-
-        if (file->get().dirty) {
-            if (auto res = co_await context.cache.flush(id()); not res) {
-                co_return Unexpect{ res.error() };
-            }
-
-            refresh_stat(timespec_omit, timespec_now);
-            file->get().dirty = false;
-        }
-
-        // send hint to cache to close its associated fd for this node if exist
-        if (auto res = co_await context.cache.hint_close(id(), mode); not res) {
-            co_return Unexpect{ res.error() };
-        }
-
-        co_return Expect<void>{};
-    }
-
-    AExpect<void> Node::utimens(Context context, timespec atime, timespec mtime)
-    {
-        if (auto res = co_await context.connection.utimens(context.path, atime, mtime); not res) {
-            co_return Unexpect{ res.error() };
-        }
-        co_return (co_await context.connection.stat(context.path)).transform([&](Stat stat) {
-            m_stat = std::move(stat);
-        });
-    }
-
-    Expect<Str> Node::readlink()
-    {
-        auto link = as<node::Link>();
-        if (not link) {
-            return Unexpect{ link.error() };
-        }
-        return link->get().target;
+        return as<node::Directory>();
     }
 }

--- a/madbfs/src/operations.cpp
+++ b/madbfs/src/operations.cpp
@@ -20,20 +20,20 @@ namespace
     /**
      * @brief Interface sync code of FUSE with async code of madbfs on the tree access using future.
      *
-     * @param fn The member function of `FileTree`.
+     * @param fn The member function of `Filesystem`.
      * @param args Arguments to be passed into the member function.
      *
      * @return The return value of the member function.
      */
     template <typename Ret, typename... Args>
     Ret invoke_tree(
-        madbfs::Await<Ret> (madbfs::tree::FileTree::*fn)(Args...),
+        madbfs::Await<Ret> (madbfs::Filesystem::*fn)(Args...),
         std::type_identity_t<Args>... args
     ) noexcept
     {
         auto& data = get_data();
         auto& ctx  = data.async_ctx();
-        auto& tree = data.tree();
+        auto& tree = data.filesystem();
 
         try {
             auto coro = (tree.*fn)(std::forward<Args>(args)...);
@@ -101,8 +101,6 @@ namespace
 
 namespace madbfs::operations
 {
-    using tree::FileTree;
-
     void* init(fuse_conn_info* conn, fuse_config*) noexcept
     {
         if (conn->want & FUSE_CAP_ATOMIC_O_TRUNC) {
@@ -154,7 +152,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         auto named_stat = ok_or(path::create(path), Errc::operation_not_supported).and_then([](path::Path p) {
-            return invoke_tree(&FileTree::getattr, p);
+            return invoke_tree(&Filesystem::getattr, p);
         });
         if (not named_stat.has_value()) {
             return fuse_err(__func__, path)(named_stat.error());
@@ -184,7 +182,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return invoke_tree(&FileTree::readlink, p); })
+            .and_then([](path::Path p) { return invoke_tree(&Filesystem::readlink, p); })
             .and_then([&](Str target) -> Expect<void> {
                 if (target.size() < 1) {
                     return Unexpect{ Errc::invalid_argument };
@@ -219,7 +217,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([=](path::Path p) { return invoke_tree(&FileTree::mknod, p, mode, dev); })
+            .and_then([=](path::Path p) { return invoke_tree(&Filesystem::mknod, p, mode, dev); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -229,7 +227,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([=](path::Path p) { return invoke_tree(&FileTree::mkdir, p, mode | S_IFDIR); })
+            .and_then([=](path::Path p) { return invoke_tree(&Filesystem::mkdir, p, mode | S_IFDIR); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -239,7 +237,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return invoke_tree(&FileTree::unlink, p); })
+            .and_then([](path::Path p) { return invoke_tree(&Filesystem::unlink, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -249,7 +247,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return invoke_tree(&FileTree::rmdir, p); })
+            .and_then([](path::Path p) { return invoke_tree(&Filesystem::rmdir, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -269,7 +267,7 @@ namespace madbfs::operations
             return fuse_err(__func__, to)(Errc::operation_not_supported);
         }
 
-        return invoke_tree(&FileTree::rename, *from_path, *to_path, flags)
+        return invoke_tree(&Filesystem::rename, *from_path, *to_path, flags)
             .transform_error(fuse_err(__func__, from))
             .error_or(0);
     }
@@ -279,7 +277,7 @@ namespace madbfs::operations
         log_i(__func__, "[size={}] {:?}", size, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&FileTree::truncate, p, size); })
+            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::truncate, p, size); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -289,7 +287,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?} [flags={:#08o}]", path, fi->flags);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&FileTree::open, p, fi->flags); })
+            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::open, p, fi->flags); })
             .transform([&](u64 fd) { fi->fh = fd; })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
@@ -300,7 +298,7 @@ namespace madbfs::operations
         log_i(__func__, "[offset={}|size={}] {:?}", offset, size, path);
 
         auto res = ok_or(path::create(path), Errc::operation_not_supported).and_then([&](path::Path p) {
-            return invoke_tree(&FileTree::read, p, fi->fh, { buf, size }, offset);
+            return invoke_tree(&Filesystem::read, p, fi->fh, { buf, size }, offset);
         });
         return res.has_value() ? static_cast<i32>(res.value()) : fuse_err(__func__, path)(res.error());
     }
@@ -310,7 +308,7 @@ namespace madbfs::operations
         log_i(__func__, "[offset={}|size={}] {:?}", offset, size, path);
 
         auto res = ok_or(path::create(path), Errc::operation_not_supported).and_then([&](path::Path p) {
-            return invoke_tree(&FileTree::write, p, fi->fh, { buf, size }, offset);
+            return invoke_tree(&Filesystem::write, p, fi->fh, { buf, size }, offset);
         });
         return res.has_value() ? static_cast<i32>(res.value()) : fuse_err(__func__, path)(res.error());
     }
@@ -320,7 +318,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&FileTree::flush, p, fi->fh); })
+            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::flush, p, fi->fh); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -330,7 +328,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&FileTree::release, p, fi->fh); })
+            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::release, p, fi->fh); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -349,7 +347,7 @@ namespace madbfs::operations
         const auto fill = [&](const char* name) { filler(buf, name, nullptr, 0, FUSE_FILL_DIR_PLUS); };
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&FileTree::readdir, p, fill); })
+            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::readdir, p, fill); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -364,7 +362,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&FileTree::utimens, p, tv[0], tv[1]); })
+            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::utimens, p, tv[0], tv[1]); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -393,7 +391,7 @@ namespace madbfs::operations
             return fuse_err(__func__, out_path)(Errc::operation_not_supported);
         }
 
-        auto op  = &FileTree::copy_file_range;
+        auto op  = &Filesystem::copy_file_range;
         auto res = invoke_tree(op, *in, in_fi->fh, in_off, *out, out_fi->fh, out_off, size);
         return res ? static_cast<isize>(res.value()) : fuse_err(__func__, in_path)(res.error());
     }

--- a/madbfs/src/operations.cpp
+++ b/madbfs/src/operations.cpp
@@ -26,17 +26,17 @@ namespace
      * @return The return value of the member function.
      */
     template <typename Ret, typename... Args>
-    Ret invoke_tree(
+    Ret invoke_fs(
         madbfs::Await<Ret> (madbfs::Filesystem::*fn)(Args...),
         std::type_identity_t<Args>... args
     ) noexcept
     {
         auto& data = get_data();
-        auto& ctx  = data.async_ctx();
-        auto& tree = data.filesystem();
+        auto& ctx  = data.ctx();
+        auto& fs   = data.fs();
 
         try {
-            auto coro = (tree.*fn)(std::forward<Args>(args)...);
+            auto coro = (fs.*fn)(std::forward<Args>(args)...);
             return madbfs::async::block(ctx, std::move(coro));
         } catch (const std::exception& e) {
             madbfs::log_c(__func__, "exception occurred: {}", e.what());
@@ -152,7 +152,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         auto named_stat = ok_or(path::create(path), Errc::operation_not_supported).and_then([](path::Path p) {
-            return invoke_tree(&Filesystem::getattr, p);
+            return invoke_fs(&Filesystem::getattr, p);
         });
         if (not named_stat.has_value()) {
             return fuse_err(__func__, path)(named_stat.error());
@@ -168,7 +168,7 @@ namespace madbfs::operations
         stbuf->st_uid     = stat.uid;
         stbuf->st_gid     = stat.gid;
         stbuf->st_size    = stat.size;
-        stbuf->st_blksize = static_cast<blksize_t>(get_data().cache().page_size());
+        stbuf->st_blksize = static_cast<blksize_t>(get_data().fs().cache().page_size());
         stbuf->st_blocks  = (stbuf->st_size + 511) / 512;    // strictly in 512 B units [read stat(3)]
         stbuf->st_atim    = stat.atime;
         stbuf->st_mtim    = stat.mtime;
@@ -182,7 +182,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return invoke_tree(&Filesystem::readlink, p); })
+            .and_then([](path::Path p) { return invoke_fs(&Filesystem::readlink, p); })
             .and_then([&](Str target) -> Expect<void> {
                 if (target.size() < 1) {
                     return Unexpect{ Errc::invalid_argument };
@@ -217,7 +217,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([=](path::Path p) { return invoke_tree(&Filesystem::mknod, p, mode, dev); })
+            .and_then([=](path::Path p) { return invoke_fs(&Filesystem::mknod, p, mode, dev); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -227,7 +227,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([=](path::Path p) { return invoke_tree(&Filesystem::mkdir, p, mode | S_IFDIR); })
+            .and_then([=](path::Path p) { return invoke_fs(&Filesystem::mkdir, p, mode | S_IFDIR); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -237,7 +237,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return invoke_tree(&Filesystem::unlink, p); })
+            .and_then([](path::Path p) { return invoke_fs(&Filesystem::unlink, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -247,7 +247,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return invoke_tree(&Filesystem::rmdir, p); })
+            .and_then([](path::Path p) { return invoke_fs(&Filesystem::rmdir, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -267,7 +267,7 @@ namespace madbfs::operations
             return fuse_err(__func__, to)(Errc::operation_not_supported);
         }
 
-        return invoke_tree(&Filesystem::rename, *from_path, *to_path, flags)
+        return invoke_fs(&Filesystem::rename, *from_path, *to_path, flags)
             .transform_error(fuse_err(__func__, from))
             .error_or(0);
     }
@@ -277,7 +277,7 @@ namespace madbfs::operations
         log_i(__func__, "[size={}] {:?}", size, path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::truncate, p, size); })
+            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::truncate, p, size); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -287,7 +287,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?} [flags={:#08o}]", path, fi->flags);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::open, p, fi->flags); })
+            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::open, p, fi->flags); })
             .transform([&](u64 fd) { fi->fh = fd; })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
@@ -297,9 +297,7 @@ namespace madbfs::operations
     {
         log_i(__func__, "[offset={}|size={}] {:?}", offset, size, path);
 
-        auto res = ok_or(path::create(path), Errc::operation_not_supported).and_then([&](path::Path p) {
-            return invoke_tree(&Filesystem::read, p, fi->fh, { buf, size }, offset);
-        });
+        auto res = invoke_fs(&Filesystem::read, fi->fh, { buf, size }, offset);
         return res.has_value() ? static_cast<i32>(res.value()) : fuse_err(__func__, path)(res.error());
     }
 
@@ -307,9 +305,7 @@ namespace madbfs::operations
     {
         log_i(__func__, "[offset={}|size={}] {:?}", offset, size, path);
 
-        auto res = ok_or(path::create(path), Errc::operation_not_supported).and_then([&](path::Path p) {
-            return invoke_tree(&Filesystem::write, p, fi->fh, { buf, size }, offset);
-        });
+        auto res = invoke_fs(&Filesystem::write, fi->fh, { buf, size }, offset);
         return res.has_value() ? static_cast<i32>(res.value()) : fuse_err(__func__, path)(res.error());
     }
 
@@ -317,20 +313,16 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?}", path);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::flush, p, fi->fh); })
-            .transform_error(fuse_err(__func__, path))
-            .error_or(0);
+        auto res = invoke_fs(&Filesystem::flush, fi->fh);
+        return res.transform_error(fuse_err(__func__, path)).error_or(0);
     }
 
     i32 release(const char* path, fuse_file_info* fi) noexcept
     {
         log_i(__func__, "{:?}", path);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::release, p, fi->fh); })
-            .transform_error(fuse_err(__func__, path))
-            .error_or(0);
+        auto res = invoke_fs(&Filesystem::release, fi->fh);
+        return res.transform_error(fuse_err(__func__, path)).error_or(0);
     }
 
     i32 readdir(
@@ -347,7 +339,7 @@ namespace madbfs::operations
         const auto fill = [&](const char* name) { filler(buf, name, nullptr, 0, FUSE_FILL_DIR_PLUS); };
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::readdir, p, fill); })
+            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::readdir, p, fill); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -362,7 +354,7 @@ namespace madbfs::operations
         log_i(__func__, "{:?}", path);
 
         return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_tree(&Filesystem::utimens, p, tv[0], tv[1]); })
+            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::utimens, p, tv[0], tv[1]); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -392,7 +384,7 @@ namespace madbfs::operations
         }
 
         auto op  = &Filesystem::copy_file_range;
-        auto res = invoke_tree(op, *in, in_fi->fh, in_off, *out, out_fi->fh, out_off, size);
+        auto res = invoke_fs(op, *in, in_fi->fh, in_off, *out, out_fi->fh, out_off, size);
         return res ? static_cast<isize>(res.value()) : fuse_err(__func__, in_path)(res.error());
     }
 }

--- a/test/test_tree.cpp
+++ b/test/test_tree.cpp
@@ -1,8 +1,8 @@
+#include "madbfs/filesystem.hpp"
 #include <madbfs-common/util/split.hpp>
 #include <madbfs/connection.hpp>
+#include <madbfs/node.hpp>
 #include <madbfs/path.hpp>
-#include <madbfs/tree/file_tree.hpp>
-#include <madbfs/tree/node.hpp>
 
 #include <boost/ut.hpp>
 #include <dtlx/dtlx.hpp>
@@ -71,11 +71,11 @@ constexpr auto expected_rm = R"(
 
 // NOTE: since there is no ordering guarantee from the VFS, this formatter just order them alphabetically
 template <>
-struct fmt::formatter<madbfs::tree::Node> : fmt::formatter<Str>
+struct fmt::formatter<madbfs::Node> : fmt::formatter<Str>
 {
-    auto format(const madbfs::tree::Node& node, auto&& ctx) const
+    auto format(const madbfs::Node& node, auto&& ctx) const
     {
-        using namespace madbfs::tree;
+        using namespace madbfs;
 
         auto print_impl = [&](this auto&& self, const Node* node, usize depth) -> void {
             if (node == nullptr) {
@@ -215,96 +215,14 @@ int main()
     spdlog::set_default_logger(spdlog::null_logger_mt("madbfs-test-tree"));
     // spdlog::set_level(spdlog::level::debug);
 
-    "constructed tree from raw node have same shape"_test = [&] {
-        using namespace madbfs::tree;
-
-        using madbfs::path::operator""_path;
-
-        auto context    = madbfs::async::Context{};
-        auto guard      = madbfs::net::make_work_guard(context);
-        auto thread     = std::jthread{ [&] { context.run(); } };
-        auto connection = madbfs::Connection{ context, mock::dummy_strategy };
-        auto cache      = madbfs::data::Cache{ connection, 64 * 1024, 1024 };
-        auto counter    = std::atomic<u64>{};
-
-        // NOTE: operations like mknod and mkdir only considers filename
-        // NOTE: full path only matter for connection and caching
-        auto dummy = madbfs::path::PathBuf{};
-        auto path  = madbfs::path::Path{};
-
-        auto make_context = [&](Str name) {
-            dummy.extend(name);
-            path = dummy.view();
-            return Node::Context{ connection, cache, counter, path };
-        };
-
-#define unwrap() transform_error([](auto e) { return raise_expect_error<Node*>(e); }).value()
-
-        auto coro = [&] -> madbfs::Await<void> {
-            auto root = Node{ "/", nullptr, {}, node::Directory{} };
-
-            Node& hello = (co_await root.mkdir(make_context("hello"), 0)).unwrap();
-
-            std::ignore = (co_await hello.mknod(make_context("world.txt"), 0, 0)).unwrap();
-            std::ignore = (co_await hello.mknod(make_context("foo.txt"), 0, 0)).unwrap();
-            std::ignore = (co_await hello.mknod(make_context("movie.mp4"), 0, 0)).unwrap();
-
-            Node& bar = (co_await hello.mkdir(make_context("bar"), 0)).unwrap();
-
-            std::ignore = (co_await bar.mknod(make_context("baz.txt"), 0, 0)).unwrap();
-            std::ignore = (co_await bar.mknod(make_context("qux.txt"), 0, 0)).unwrap();
-            std::ignore = (co_await bar.mknod(make_context("quux.txt"), 0, 0)).unwrap();
-
-            Node& bye = (co_await root.mkdir(make_context("bye"), 0)).unwrap();
-
-            std::ignore = (co_await bye.mknod(make_context("world.txt"), 0, 0)).unwrap();
-            std::ignore = (co_await bye.mknod(make_context("movie.mp4"), 0, 0)).unwrap();
-            std::ignore = (co_await bye.mknod(make_context("music.mp3"), 0, 0)).unwrap();
-
-            Node& family = (co_await bye.mkdir(make_context("family"), 0)).unwrap();
-
-            std::ignore = (co_await family.mknod(make_context("dad.txt"), 0, 0)).unwrap();
-            std::ignore = (co_await family.mknod(make_context("mom.txt"), 0, 0)).unwrap();
-
-            Node& friends = (co_await bye.mkdir(make_context("friends"), 0)).unwrap();
-
-            std::ignore = (co_await friends.mknod(make_context("bob.txt"), 0, 0)).unwrap();
-
-            Node& school = (co_await friends.mkdir(make_context("school"), 0)).unwrap();
-
-            std::ignore = (co_await school.mknod(make_context("kal'tsit.txt"), 0, 0)).unwrap();
-            std::ignore = (co_await school.mknod(make_context("closure.txt"), 0, 0)).unwrap();
-
-            Node& work = (co_await friends.mkdir(make_context("work"), 0)).unwrap();
-
-            Node& wife = (co_await work.mknod(make_context("loughshinny <3.txt"), 0, 0)).unwrap();
-
-            std::ignore = (co_await work.mknod(make_context("eblana?.mp4"), 0, 0)).unwrap();
-            std::ignore = school.symlink("hehe", work.build_path().str()).unwrap();
-            std::ignore = hello.symlink("wife", wife.build_path().str()).unwrap();
-            std::ignore = (co_await bye.mknod(make_context("theresa.txt"), 0, 0)).unwrap();
-
-            auto tree_str = fmt::format("\n{}", root);
-            expect(expected == tree_str) << diff_str(expected, tree_str);
-        };
-
-#undef unwrap
-
-        madbfs::async::block(context, coro());
-
-        guard.reset();
-        context.stop();
-    };
-
     "constructed FileTree have same shape"_test = [&] {
-        using namespace madbfs::tree;
+        using namespace madbfs;
 
         auto context    = madbfs::async::Context{};
         auto guard      = madbfs::net::make_work_guard(context);
         auto thread     = std::jthread{ [&] { context.run(); } };
         auto connection = madbfs::Connection{ context, mock::dummy_strategy };
-        auto cache      = madbfs::data::Cache{ connection, 64 * 1024, 1024 };
-        auto tree       = FileTree{ connection, cache, std::nullopt };
+        auto tree       = Filesystem{ connection, 64 * 1024, 1024, std::nullopt };
 
         using madbfs::path::operator""_path;
 
@@ -355,7 +273,7 @@ int main()
             auto dummy = bar.build_path();
             dummy.extend("dummy");
 
-            auto entries = bar.list()->get()                                         //
+            auto entries = bar.as<madbfs::node::Directory>(false)->get().children()
                          | sv::transform([](auto& node) { return node->name(); })    //
                          | sr::to<Vec<String>>();
 


### PR DESCRIPTION
To make operations faster, I implemented an array that stores open file handle information. It is wrapped inside `FileHandleStore`. The array contains the Node the file pointed to and its open mode. This allows for constant access to the node that will be read/written by using its index as fd.

In the meantime I also restructure the filesystem code to have less indirection.