### PR TITLE
Implement no cache

### DIFF
--- a/madbfs-common/include/madbfs-common/ipc.hpp
+++ b/madbfs-common/include/madbfs-common/ipc.hpp
@@ -219,7 +219,7 @@ namespace madbfs::ipc
     {
     public:
         using Acceptor = async::unix_socket::Acceptor;
-        using OnFsOp   = std::move_only_function<Await<boost::json::value>(ipc::FsOp op)>;
+        using OnFsOp   = std::move_only_function<AExpect<boost::json::value>(ipc::FsOp op)>;
 
         /**
          * @brief Create IPC server.

--- a/madbfs-common/src/ipc.cpp
+++ b/madbfs-common/src/ipc.cpp
@@ -343,9 +343,11 @@ namespace madbfs::ipc
             status = "success";
 
             switch (op->index()) {
-            case Op::index_of<FsOp>():
-                value = co_await m_on_op(std::move(*op->as<FsOp>()));    //
-                break;
+            case Op::index_of<FsOp>(): {
+                auto res = co_await m_on_op(std::move(*op->as<FsOp>()));
+                status   = res ? "success" : "error";
+                value    = res.value_or(json::value{ err_msg(res.error()) });
+            } break;
             case Op::index_of<op::Help>():
                 value = json::value{ { "operations", json::value_from(op::names) } };
                 break;

--- a/madbfs/include/madbfs/args.hpp
+++ b/madbfs/include/madbfs/args.hpp
@@ -33,6 +33,7 @@ namespace madbfs::args
         int         port       = 23237;
         int         no_server  = false;
         int         adb_only   = false;
+        int         no_cache   = false;
 
         ~MadbfsOpt()
         {
@@ -57,6 +58,12 @@ namespace madbfs::args
         using VarWrapper::VarWrapper;
     };
 
+    struct Caching
+    {
+        usize cachesize;
+        usize pagesize;
+    };
+
     /**
      * @class ParsedOpt
      *
@@ -64,15 +71,14 @@ namespace madbfs::args
      */
     struct ParsedOpt
     {
-        String     mount;
-        String     serial;
-        Connection connection;
-        log::Level log_level;
-        String     log_file;
-        usize      cachesize;
-        usize      pagesize;
-        i32        ttl;
-        i32        timeout;
+        String       mount;
+        String       serial;
+        Connection   connection;
+        Opt<Caching> caching;
+        log::Level   log_level;
+        String       log_file;
+        i32          ttl;
+        i32          timeout;
     };
 
     /**
@@ -115,6 +121,7 @@ namespace madbfs::args
         { "--port=%d",       offsetof(MadbfsOpt, port),       true },
         { "--no-server",     offsetof(MadbfsOpt, no_server),  true },
         { "--adb-only",      offsetof(MadbfsOpt, adb_only),   true },
+        { "--no-cache",      offsetof(MadbfsOpt, no_cache),   true },
         // clang-format on
         FUSE_OPT_END,
     });

--- a/madbfs/include/madbfs/cache.hpp
+++ b/madbfs/include/madbfs/cache.hpp
@@ -69,7 +69,10 @@ namespace madbfs
      * files. Each element in the LRU is a `Page` that represents a portion of a file being stored. This
      * pages are interleaved between files (cross-file).
      *
-     * The class also acts as debouncer for read/write operations.
+     * This Cache stores a pair of real fds for read and write operations, even when the FUSE client opens
+     * multiple files. Every file is discriminated by its id. Real fds are not exposed through this mode.
+     *
+     * The class also acts as debouncer for read/write operations because of the nature of it.
      */
     class Cache
     {
@@ -115,11 +118,13 @@ namespace madbfs
         };
 
         /**
-         * @brief Construct a new cache.
+         * @brief Create a new LRU-based cache.
          *
-         * @param connection Connection to device.
-         * @param page_size Page size.
-         * @param max_pages Maximum number of pages cached.
+         * @param connection Conneciton to device.
+         * @param page_size Cache page size.
+         * @param max_pages Number of maximum pages the Cache can hold.
+         *
+         * The connection will be held by the instance until it is destroyed.
          */
         Cache(Connection& connection, usize page_size, usize max_pages);
 
@@ -201,6 +206,8 @@ namespace madbfs
          *
          * @param id File id.
          * @param new_name New path for the file.
+         *
+         * This function only renames path in the cumulative fd map, not the real device.
          */
         Await<void> rename(Id id, path::Path new_name);
 
@@ -222,7 +229,7 @@ namespace madbfs
         /**
          * @brief Shut down the cache and invalidate all cache entries.
          *
-         * Calling this function is the same as calling `shutdown()`
+         * Calling this function is the same as calling `invalidate_all()`
          */
         Await<void> shutdown();
 
@@ -241,11 +248,33 @@ namespace madbfs
          */
         Await<void> invalidate_fds(bool close);
 
+        /**
+         * @brief Set new page size for the cache.
+         *
+         * @param new_page_size Non-zero integer; power of 2.
+         */
         Await<void> set_page_size(usize new_page_size);
+
+        /**
+         * @brief Set new maximum number of pages the cache able to hold.
+         *
+         * @param new_page_size Non-zero integer.
+         */
         Await<void> set_max_pages(usize new_max_pages);
 
+        /**
+         * @brief Get the cache page size.
+         */
         usize page_size() const { return m_page_size; }
+
+        /**
+         * @brief Get the cache max pages.
+         */
         usize max_pages() const { return m_max_pages; }
+
+        /**
+         * @brief Get current number of pages held by cache.
+         */
         usize current_pages() const { return m_lru.size(); }
 
     private:

--- a/madbfs/include/madbfs/file_handle_store.hpp
+++ b/madbfs/include/madbfs/file_handle_store.hpp
@@ -13,6 +13,7 @@ namespace madbfs
     {
         Node*    node;
         OpenMode mode;
+        u64      real_fd;    // only useful for direct IO; Cache is not enabled
     };
 
     /**
@@ -32,11 +33,11 @@ namespace madbfs
          *
          * @param fd File descriptor.
          *
-         * @return FileHandle if exists, else default initialized FileHandle.
+         * @return FileHandle if exists, else `std::nullopt`.
          *
          * The complexity of the operation is constant.
          */
-        FileHandle find(u64 fd);
+        Opt<FileHandle> find(u64 fd);
 
         /**
          * @brief Get associated `Node` from file handle store for file descriptor with specified open mode.
@@ -44,34 +45,35 @@ namespace madbfs
          * @param fd File descriptor.
          * @param mode Open file mode.
          *
-         * @return The node if found and fulfill the mode else `Errc::bad_file_descriptor`.
+         * @return The node if found and fulfill the mode else `std::nullopt`.
          *
          * The complexity of the operation is constant.
          */
-        Node* find(u64 fd, OpenMode mode);
+        Opt<FileHandle> find(u64 fd, OpenMode mode);
 
         /**
          * @brief Store `Node` pointer into file handle store.
          *
          * @param node The node to be inserted.
          * @param mode Open file mode for the node.
+         * @param real_fd Real file descriptor (only useful for direct IO).
          *
          * @return File descriptor (position of the node in the store).
          *
          * The complexity of the opration is linear (depends on number of handles before finding a hole).
          */
-        u64 store(Node* node, OpenMode mode);
+        u64 store(Node* node, OpenMode mode, u64 real_fd);
 
         /**
          * @brief Release the associated node of file descriptor from the file handle store.
          *
          * @param fd File descriptor.
          *
-         * @return The released node if exists, else default initialized FileHandle.
+         * @return The released node if exists, else `std::nullopt`.
          *
          * The complexity of the operation is constant.
          */
-        FileHandle release(u64 fd);
+        Opt<FileHandle> release(u64 fd);
 
         /**
          * @brief Erase any pointer to node.
@@ -84,13 +86,14 @@ namespace madbfs
          */
         usize erase(Node* node);
 
-        FRange auto iter() { return sv::zip(m_nodes, m_modes); }
-        FRange auto iter() const { return sv::zip(m_nodes, m_modes); }
+        Span<FileHandle>       iter() { return m_handles; }
+        Span<const FileHandle> iter() const { return m_handles; }
 
-        usize size() const { return m_nodes.size(); }
+        usize capacity() const { return m_handles.size(); }
+        usize count_open() const;
+        usize count_empty() const;
 
     private:
-        std::vector<Node*>    m_nodes;
-        std::vector<OpenMode> m_modes;
+        Vec<FileHandle> m_handles;
     };
 }

--- a/madbfs/include/madbfs/filesystem.hpp
+++ b/madbfs/include/madbfs/filesystem.hpp
@@ -6,6 +6,7 @@
 #include "madbfs/path.hpp"
 
 #include <madbfs-common/async/async.hpp>
+#include <madbfs-common/util/var_wrapper.hpp>
 
 #include <functional>
 
@@ -16,6 +17,17 @@ namespace madbfs
 
 namespace madbfs
 {
+    /**
+     * @class Caching
+     *
+     * @brief Parameters to be passed into Cache constructor.
+     */
+    struct Caching
+    {
+        usize page_size;
+        usize max_pages;
+    };
+
     /**
      * @class Filesystem
      *
@@ -32,11 +44,10 @@ namespace madbfs
          * @brief Create a new filesystem.
          *
          * @param connection Reference to active conneciton to device.
-         * @param page_size Cache page size.
-         * @param max_pages Maximum number of pages to be saved on the cache.
+         * @param caching Cache parameters or empty for no caching.
          * @param ttl Filesystem node's stat expiration time before re-fetching.
          */
-        Filesystem(Connection& connection, usize page_size, usize max_pages, Opt<Seconds> ttl);
+        Filesystem(Connection& connection, Opt<Caching> caching, Opt<Seconds> ttl);
 
         /**
          * @brief Destroy filesystem.
@@ -117,11 +128,12 @@ namespace madbfs
         /**
          * @brief Get cache structure.
          */
-        template <typename Self>
-        auto&& cache(this Self&& self)
-        {
-            return std::forward_like<Self>(self.m_cache);
-        }
+        const Opt<Cache>& cache() const { return m_cache; }
+
+        /**
+         * @brief Get cache structure.
+         */
+        Opt<Cache>& cache() { return m_cache; }
 
         /**
          * @brief Get root node.
@@ -138,7 +150,7 @@ namespace madbfs
         /**
          * @brief Get open file handle store.
          */
-        FileHandleStore& handles() { return m_handles; }
+        const FileHandleStore& handles() { return m_handles; }
 
     private:
         /**
@@ -194,7 +206,7 @@ namespace madbfs
         Connection& m_connection;
 
         Node            m_root;
-        Cache           m_cache;
+        Opt<Cache>      m_cache;
         FileHandleStore m_handles;
 
         Opt<Seconds> m_ttl              = std::nullopt;

--- a/madbfs/include/madbfs/madbfs.hpp
+++ b/madbfs/include/madbfs/madbfs.hpp
@@ -26,8 +26,7 @@ namespace madbfs
         Madbfs(
             struct fuse*     fuse,
             args::Connection connection,
-            usize            max_pages,
-            usize            page_size,
+            Opt<Caching>     caching,
             Str              mount_point,
             Opt<Seconds>     ttl,
             Opt<Seconds>     timeout

--- a/madbfs/include/madbfs/madbfs.hpp
+++ b/madbfs/include/madbfs/madbfs.hpp
@@ -77,7 +77,7 @@ namespace madbfs
          *
          * This function handles all requested operations from peers that comes from `m_ipc` instance.
          */
-        Await<boost::json::value> ipc_handler(ipc::FsOp op);
+        AExpect<boost::json::value> ipc_handler(ipc::FsOp op);
 
         /**
          * @brief Watch connection status.

--- a/madbfs/src/args.cpp
+++ b/madbfs/src/args.cpp
@@ -165,11 +165,13 @@ namespace madbfs::args
             "                             (default: 256)\n"
             "                             (minimum: 128)\n"
             "                             (value will be rounded up to the next power of 2)\n"
+            "                             (ignored if 'no-cache' is provided)\n"
             "    --page-size=<int>      page size for cache & transfer in KiB\n"
             "                             (default: 128)\n"
             "                             (minimum: 64)\n"
             "                             (maximum: 4096)\n"
             "                             (value will be rounded up to the next power of 2)\n"
+            "                             (ignored if 'no-cache' is provided)\n"
             "    --ttl=<int>            set the TTL of the stat cache of the filesystem in seconds\n"
             "                             (default: 60)\n"
             "                             (set to 0 to disable it)\n"
@@ -182,7 +184,8 @@ namespace madbfs::args
             "                             (will still attempt to connect to specified port)\n"
             "                             (fall back to adb shell calls if connection failed)\n"
             "                             (useful for debugging the server)\n"
-            "    --adb-only             don't launch server and don't try to connect\n",
+            "    --adb-only             don't launch server and don't try to connect\n"
+            "    --no-cache             don't use data caching\n",
             log::level_names
         );
 
@@ -362,18 +365,22 @@ namespace madbfs::args
                           ? ""
                           : madbfs_opt.log_file;
 
-        auto cache_size = std::max(std::bit_ceil(static_cast<usize>(madbfs_opt.cache_size)), 128uz);
-        auto page_size  = std::clamp(std::bit_ceil(static_cast<usize>(madbfs_opt.page_size)), 64uz, 4096uz);
+        auto caching = Opt<Caching>{};
+        if (not madbfs_opt.no_cache) {
+            caching = Caching{
+                .cachesize = std::max(std::bit_ceil(static_cast<usize>(madbfs_opt.cache_size)), 128uz),
+                .pagesize = std::clamp(std::bit_ceil(static_cast<usize>(madbfs_opt.page_size)), 64uz, 4096uz),
+            };
+        }
 
         co_return ParseResult::Opt{
             .opt = {
                 .mount      = std::move(mountpoint),
                 .serial     = madbfs_opt.serial,
                 .connection = connection,
+                .caching    = caching,
                 .log_level  = log_level.value(),
                 .log_file   = log_file,
-                .cachesize  = cache_size,
-                .pagesize   = page_size,
                 .ttl        = madbfs_opt.ttl,
                 .timeout    = madbfs_opt.timeout,
             },

--- a/madbfs/src/file_handle_store.cpp
+++ b/madbfs/src/file_handle_store.cpp
@@ -2,68 +2,78 @@
 
 #include "madbfs/node.hpp"
 
+#include <algorithm>
 #include <utility>
 
 namespace madbfs
 {
-    FileHandle FileHandleStore::find(u64 fd)
+    Opt<FileHandle> FileHandleStore::find(u64 fd)
     {
-        return fd < m_nodes.size() ? FileHandle{ m_nodes[fd], m_modes[fd] } : FileHandle{};
+        return fd < m_handles.size() ? Opt{ m_handles[fd] } : std::nullopt;
     }
 
-    Node* FileHandleStore::find(u64 fd, OpenMode mode)
+    Opt<FileHandle> FileHandleStore::find(u64 fd, OpenMode mode)
     {
-        if (fd >= m_nodes.size()) {
-            return nullptr;
+        if (fd >= m_handles.size()) {
+            return std::nullopt;
         }
 
-        auto ok   = m_modes[fd] == mode or m_modes[fd] == OpenMode::ReadWrite;
-        auto node = m_nodes[fd];
+        auto handle = m_handles[fd];
+        auto ok     = handle.mode == mode or handle.mode == OpenMode::ReadWrite;
 
-        return node and ok ? node : nullptr;
+        return handle.node and ok ? Opt{ handle } : std::nullopt;
     }
 
-    u64 FileHandleStore::store(Node* node, OpenMode mode)
+    u64 FileHandleStore::store(Node* node, OpenMode mode, u64 real_fd)
     {
-        if (auto found = sr::find(m_nodes, nullptr); found != m_nodes.end()) {
-            auto dist     = static_cast<usize>(found - m_nodes.begin());
-            m_nodes[dist] = node;
-            m_modes[dist] = mode;
+        if (auto found = sr::find(m_handles, nullptr, &FileHandle::node); found != m_handles.end()) {
+            auto dist               = static_cast<usize>(found - m_handles.begin());
+            m_handles[dist].node    = node;
+            m_handles[dist].mode    = mode;
+            m_handles[dist].real_fd = real_fd;
             return dist;
         }
 
-        auto size = m_nodes.size();
+        auto size = m_handles.size();
 
-        if (m_nodes.empty()) {
-            m_nodes.resize(1024, {});    // 1024 seats by default is reasonable I guess
-            m_modes.resize(1024, {});
+        if (m_handles.empty()) {
+            m_handles.resize(1024, {});    // 1024 seats by default is reasonable I guess
         } else {
-            m_nodes.resize(size * 2, {});    // should I add upper limit?
-            m_modes.resize(size * 2, {});
+            m_handles.resize(size * 2, {});    // should I add upper limit?
         }
 
-        m_nodes[size] = node;
-        m_modes[size] = mode;
+        m_handles[size].node    = node;
+        m_handles[size].mode    = mode;
+        m_handles[size].real_fd = real_fd;
 
         return size;
     }
 
-    FileHandle FileHandleStore::release(u64 fd)
+    Opt<FileHandle> FileHandleStore::release(u64 fd)
     {
-        return fd < m_nodes.size()
-                 ? FileHandle{ std::exchange(m_nodes[fd], {}), std::exchange(m_modes[fd], {}) }
-                 : FileHandle{};
+        return fd < m_handles.size() ? Opt{ std::exchange(m_handles[fd], {}) } : std::nullopt;
     }
 
     usize FileHandleStore::erase(Node* node)
     {
         auto count = 0uz;
-        for (auto& v : m_nodes) {
-            if (v == node) {
-                v = nullptr;
+        for (auto& v : m_handles) {
+            if (v.node == node) {
+                v.node = nullptr;
                 ++count;
             }
         }
         return count;
+    }
+
+    usize FileHandleStore::count_open() const
+    {
+        auto count = sr::count_if(m_handles, [](const FileHandle& h) { return h.node != nullptr; });
+        return static_cast<usize>(count);
+    }
+
+    usize FileHandleStore::count_empty() const
+    {
+        return capacity() - count_open();
     }
 }

--- a/madbfs/src/filesystem.cpp
+++ b/madbfs/src/filesystem.cpp
@@ -8,11 +8,15 @@
 #include <fmt/std.h>
 #include <sys/stat.h>
 
+#include <cassert>
+
 constexpr auto timespec_now  = timespec{ .tv_sec = 0, .tv_nsec = UTIME_NOW };
 constexpr auto timespec_omit = timespec{ .tv_sec = 0, .tv_nsec = UTIME_OMIT };
 
 namespace
 {
+    using namespace madbfs;
+
     // NOTE: Errc::not_connected, Errc::timed_out, and Errc::resource_unavailable_try_again should be
     // considered an OK error since it can happen if the device is disconnected. The error should not be
     // cached as node.
@@ -22,14 +26,19 @@ namespace
            and err != std::errc::timed_out        //
            and err != std::errc::resource_unavailable_try_again;
     }
+
+    Opt<Cache> construct_cache(Connection& connection, Opt<Caching> caching)
+    {
+        return caching.transform([&](auto c) { return Cache{ connection, c.page_size, c.max_pages }; });
+    }
 }
 
 namespace madbfs
 {
-    Filesystem::Filesystem(Connection& connection, usize page_size, usize max_pages, Opt<Seconds> ttl)
+    Filesystem::Filesystem(Connection& connection, Opt<Caching> caching, Opt<Seconds> ttl)
         : m_connection{ connection }
         , m_root{ "/", nullptr, {}, node::Directory{} }
-        , m_cache{ m_connection, page_size, max_pages }
+        , m_cache{ construct_cache(connection, caching) }
         , m_ttl{ ttl }
     {
     }
@@ -224,12 +233,16 @@ namespace madbfs
             for (const auto& node : dir->children()) {
                 walk(*node, [&](Node& n) { m_handles.erase(&n), nodes.push_back(&n); });
             }
-            for (auto node : nodes) {
-                co_await m_cache.invalidate_one(node->id(), false);    // maybe flush? child might not change
+            if (m_cache) {
+                for (auto node : nodes) {
+                    co_await m_cache->invalidate_one(node->id(), false);    // flush? child maybe unchanged
+                }
             }
             m_handles.erase(&node);
         } else if (std::get_if<node::Regular>(&old)) {
-            co_await m_cache.invalidate_one(node.id(), false);    // no flush needed since the file changed
+            if (m_cache) {
+                co_await m_cache->invalidate_one(node.id(), false);    // no flush since the file changed
+            }
             m_handles.erase(&node);
         }
     }
@@ -343,7 +356,9 @@ namespace madbfs
                     auto name = (**it).name();
                     if (not new_list.contains(name)) {
                         log_d(__func__, "[{:?}]   removed: {:?}", current->name(), name);
-                        co_await m_cache.invalidate_one((**it).id(), false);    // should I flush
+                        if (m_cache) {
+                            co_await m_cache->invalidate_one((**it).id(), false);    // should I flush
+                        }
                         it = list.erase(it);
                         continue;
                     }
@@ -493,7 +508,9 @@ namespace madbfs
         }
 
         m_handles.erase(erased->get());
-        co_await m_cache.invalidate_one((*erased)->id(), false);
+        if (m_cache) {
+            co_await m_cache->invalidate_one((*erased)->id(), false);
+        }
 
         co_return Expect<void>{};
     }
@@ -572,7 +589,9 @@ namespace madbfs
         to_parent->get().refresh_stat(timespec_omit, timespec_now);
 
         auto node = from_dir.extract(from.filename()).value();
-        co_await m_cache.rename(node->id(), to);
+        if (m_cache) {
+            co_await m_cache->rename(node->id(), to);
+        }
 
         node->set_name(to.filename());
         node->set_parent(&to_parent->get());
@@ -582,14 +601,18 @@ namespace madbfs
             assert(overwritten.second != nullptr);
             auto node = std::move(overwritten).second;
 
-            co_await m_cache.rename(node->id(), from);
+            if (m_cache) {
+                co_await m_cache->rename(node->id(), from);
+            }
             node->set_name(from.filename());
             node->set_parent(from_parent);
 
             auto res = from_dir.insert(std::move(node), false);
             assert(res->second == nullptr);    // has extracted before
         } else if (overwritten.second != nullptr) {
-            co_await m_cache.invalidate_one(overwritten.second->id(), false);
+            if (m_cache) {
+                co_await m_cache->invalidate_one(overwritten.second->id(), false);
+            }
             m_handles.erase(overwritten.second.get());
         }
 
@@ -629,7 +652,9 @@ namespace madbfs
         auto new_size = static_cast<usize>(size);
 
         // error from Cache::truncate are from eviction only, which should not matter for this file
-        std::ignore = co_await m_cache.truncate(node.id(), old_size, new_size);
+        if (m_cache) {
+            std::ignore = co_await m_cache->truncate(node.id(), old_size, new_size);
+        }
 
         node.set_size(size);
         node.refresh_stat(timespec_omit, timespec_now);
@@ -650,60 +675,79 @@ namespace madbfs
         auto  mode = static_cast<OpenMode>(O_ACCMODE & flags);
 
         // send hint to cache to prepare a real fd that can be used for further operations
-        co_return (co_await m_cache.hint_open(node.id(), path, mode)).transform([&] {
-            return m_handles.store(&node, mode);
-        });
+        if (m_cache) {
+            co_return (co_await m_cache->hint_open(node.id(), path, mode)).transform([&] {
+                return m_handles.store(&node, mode, 0);
+            });
+        } else {
+            co_return (co_await m_connection.open(path, mode)).transform([&](u64 real_fd) {
+                return m_handles.store(&node, mode, real_fd);
+            });
+        }
     }
 
     AExpect<usize> Filesystem::read(u64 fd, Span<char> out, off_t offset)
     {
-        auto node = m_handles.find(fd, OpenMode::Read);
-        if (not node) {
+        auto handle = m_handles.find(fd, OpenMode::Read);
+        if (not handle) {
             co_return Unexpect{ Errc::bad_file_descriptor };
         }
 
-        co_return (co_await m_cache.read(node->id(), out, offset)).transform([&](usize ret) {
-            node->refresh_stat(timespec_now, timespec_omit);
+        auto after = [&](usize ret) {
+            handle->node->refresh_stat(timespec_now, timespec_omit);
             return ret;
-        });
+        };
+
+        if (m_cache) {
+            co_return (co_await m_cache->read(handle->node->id(), out, offset)).transform(after);
+        } else {
+            assert(handle->real_fd != 0 && "on no-cache, the file descriptor is exposed directly, not 0");
+            co_return (co_await m_connection.read(handle->real_fd, out, offset)).transform(after);
+        }
     }
 
     AExpect<usize> Filesystem::write(u64 fd, Str in, off_t offset)
     {
-        auto node = m_handles.find(fd, OpenMode::Write);
-        if (not node) {
+        auto handle = m_handles.find(fd, OpenMode::Write);
+        if (not handle) {
             co_return Unexpect{ Errc::bad_file_descriptor };
         }
 
-        auto may_file = node->as_regular();
+        auto may_file = handle->node->as_regular();
         if (not may_file) [[unlikely]] {
             co_return Unexpect{ Errc::bad_file_descriptor };
         }
 
         auto& file = may_file->get();
 
-        co_return (co_await m_cache.write(node->id(), in, offset)).transform([&](usize ret) {
+        auto after = [&](usize ret) {
             // the file size is defined as offset + size from last write if it's higher than previous size
             auto new_size = offset + static_cast<off_t>(ret);
-            auto size     = std::max(node->stat().size, new_size);
+            auto size     = std::max(handle->node->stat().size, new_size);
 
-            node->set_size(size);
-            node->refresh_stat(timespec_omit, timespec_now);
+            handle->node->set_size(size);
+            handle->node->refresh_stat(timespec_omit, timespec_now);
 
             file.dirty = true;
 
             return ret;
-        });
+        };
+
+        if (m_cache) {
+            co_return (co_await m_cache->write(handle->node->id(), in, offset)).transform(after);
+        } else {
+            co_return (co_await m_connection.write(handle->real_fd, in, offset)).transform(after);
+        }
     }
 
     AExpect<void> Filesystem::flush(u64 fd)
     {
-        auto [node, _] = m_handles.find(fd);
-        if (not node) {
+        auto handle = m_handles.find(fd);
+        if (not handle) {
             co_return Unexpect{ Errc::bad_file_descriptor };
         }
 
-        auto may_file = node->as_regular();
+        auto may_file = handle->node->as_regular();
         if (not may_file) [[unlikely]] {
             co_return Unexpect{ Errc::bad_file_descriptor };
         }
@@ -713,40 +757,46 @@ namespace madbfs
             co_return Expect<void>{};    // no writes, do nothing
         }
 
-        co_return (co_await m_cache.flush(node->id())).transform([&] {
-            node->refresh_stat(timespec_omit, timespec_now);
+        if (m_cache) {
+            co_return (co_await m_cache->flush(handle->node->id())).transform([&] {
+                handle->node->refresh_stat(timespec_omit, timespec_now);
+                file.dirty = false;
+            });
+        } else {
+            // do nothing, write already happens on write :P
             file.dirty = false;
-        });
+            co_return Expect<void>{};
+        }
     }
 
     AExpect<void> Filesystem::release(u64 fd)
     {
-        auto [node, mode] = m_handles.release(fd);
-        if (not node) {
+        auto handle = m_handles.release(fd);
+        if (not handle) {
             co_return Unexpect{ Errc::bad_file_descriptor };
         }
 
-        auto may_file = node->as_regular();
+        auto may_file = handle->node->as_regular();
         if (not may_file) [[unlikely]] {
             co_return Unexpect{ Errc::bad_file_descriptor };
         }
 
         auto& file = may_file->get();
-        if (file.dirty) {
-            if (auto res = co_await m_cache.flush(node->id()); not res) {
+        if (file.dirty and m_cache) {
+            if (auto res = co_await m_cache->flush(handle->node->id()); not res) {
                 co_return Unexpect{ res.error() };
             }
 
-            node->refresh_stat(timespec_omit, timespec_now);
+            handle->node->refresh_stat(timespec_omit, timespec_now);
             file.dirty = false;
         }
 
         // send hint to cache to close its associated fd for this node if exist
-        if (auto res = co_await m_cache.hint_close(node->id(), mode); not res) {
-            co_return Unexpect{ res.error() };
+        if (m_cache) {
+            co_return co_await m_cache->hint_close(handle->node->id(), handle->mode);
+        } else {
+            co_return co_await m_connection.close(handle->real_fd);
         }
-
-        co_return Expect<void>{};
     }
 
     AExpect<usize> Filesystem::copy_file_range(
@@ -831,7 +881,9 @@ namespace madbfs
 
     Await<void> Filesystem::shutdown()
     {
-        co_await m_cache.shutdown();
+        if (m_cache) {
+            co_await m_cache->shutdown();
+        }
     }
 
     Opt<Seconds> Filesystem::set_ttl(Opt<Seconds> ttl)

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -21,54 +21,70 @@ namespace madbfs
     // on: gcc (GCC) 15.2.1 20251211 (Red Hat 15.2.1-5).
     struct Madbfs::IpcHandler
     {
-        Await<json::value> handle(ipc::op::Info)
+        AExpect<json::value> handle(ipc::op::Info)
         {
             const auto& cache = madbfs.fs().cache();
 
-            const auto page_size     = cache.transform(&Cache::page_size).value_or(0);
-            const auto max_pages     = cache.transform(&Cache::max_pages).value_or(0);
-            const auto current_pages = cache.transform(&Cache::current_pages).value_or(0);
-            const auto ttl_sec       = madbfs.fs().ttl().transform(&Seconds::count);
-            const auto timeout_sec   = madbfs.m_timeout.transform(&Seconds::count);
-
-            co_return json::value{
-                { "connection", madbfs.m_connection.name() },
-                { "log_level", log::level_to_str(log::get_level()) },
-                { "ttl", ttl_sec.value_or(0) },
-                { "timeout", timeout_sec.value_or(0) },
-                { "page_size", page_size / 1024 },
-                { "cache_size",
-                  { { "max", page_size * max_pages / 1024 / 1024 },
-                    { "current", page_size * current_pages / 1024 / 1024 } } },
-            };
-        }
-
-        Await<json::value> handle(ipc::op::InvalidateCache)
-        {
-            auto& cache = madbfs.fs().cache();
-
-            const auto page_size     = cache.transform(&Cache::page_size).value_or(0);
-            const auto current_pages = cache.transform(&Cache::current_pages).value_or(0);
+            const auto ttl_sec     = madbfs.fs().ttl().transform(&Seconds::count).value_or(0);
+            const auto timeout_sec = madbfs.m_timeout.transform(&Seconds::count).value_or(0);
 
             if (cache) {
-                co_await cache->invalidate_all();
+                const auto page_size     = cache->page_size();
+                const auto max_pages     = cache->max_pages();
+                const auto current_pages = cache->current_pages();
+
+                co_return json::value{
+                    { "connection", madbfs.m_connection.name() },
+                    { "log_level", log::level_to_str(log::get_level()) },
+                    { "ttl", ttl_sec },
+                    { "timeout", timeout_sec },
+                    { "cache",
+                      { { "page_size", page_size / 1024 },
+                        { "cache_size",
+                          { { "max", page_size * max_pages / 1024 / 1024 },
+                            { "current", page_size * current_pages / 1024 / 1024 } } } } }
+                };
+            } else {
+                co_return json::value{
+                    { "connection", madbfs.m_connection.name() },
+                    { "log_level", log::level_to_str(log::get_level()) },
+                    { "ttl", ttl_sec },
+                    { "timeout", timeout_sec },
+                    { "cache", nullptr },
+                };
             }
+        }
+
+        AExpect<json::value> handle(ipc::op::InvalidateCache)
+        {
+            auto& cache = madbfs.fs().cache();
+            if (not cache) {
+                co_return Unexpect{ Errc::operation_not_supported };
+            }
+
+            const auto page_size     = cache->page_size();
+            const auto current_pages = cache->current_pages();
+
+            co_await cache->invalidate_all();
 
             co_return json::value{ { "size", page_size * current_pages / 1024 / 1024 } };
         }
 
-        Await<json::value> handle(ipc::op::ExpireStat)
+        AExpect<json::value> handle(ipc::op::ExpireStat)
         {
             auto count = madbfs.fs().expires_all();
             co_return json::value{ { "count", count } };
         }
 
-        Await<json::value> handle(ipc::op::SetPageSize size)
+        AExpect<json::value> handle(ipc::op::SetPageSize size)
         {
             auto& cache = madbfs.fs().cache();
+            if (not cache) {
+                co_return Unexpect{ Errc::operation_not_supported };
+            }
 
-            const auto old_size = cache.transform(&Cache::page_size).value_or(0);
-            const auto old_max  = cache.transform(&Cache::max_pages).value_or(0);
+            const auto old_size = cache->page_size();
+            const auto old_max  = cache->max_pages();
 
             auto new_size = std::bit_ceil(size.kib * 1024);
             new_size      = std::clamp(new_size, lowest_page_size, highest_page_size);
@@ -76,13 +92,8 @@ namespace madbfs
             auto new_max = std::bit_ceil(old_max * old_size / new_size);
             new_max      = std::max(new_max, lowest_max_pages);
 
-            if (cache) {
-                co_await cache->set_page_size(new_size);
-                co_await cache->set_max_pages(new_max);
-            } else {
-                new_size = 0;
-                new_max  = 0;
-            }
+            co_await cache->set_page_size(new_size);
+            co_await cache->set_max_pages(new_max);
 
             co_return json::value{
                 { "page_size",
@@ -94,14 +105,17 @@ namespace madbfs
             };
         }
 
-        Await<json::value> handle(ipc::op::SetCacheSize size)
+        AExpect<json::value> handle(ipc::op::SetCacheSize size)
         {
             auto& cache = madbfs.fs().cache();
+            if (not cache) {
+                co_return Unexpect{ Errc::operation_not_supported };
+            }
 
-            const auto page    = cache.transform(&Cache::page_size).value_or(0);
-            const auto old_max = cache.transform(&Cache::max_pages).value_or(0);
+            const auto page    = cache->page_size();
+            const auto old_max = cache->max_pages();
 
-            auto new_max = std::bit_ceil(size.mib * 1024 * 1024 / (page ? page : 1));
+            auto new_max = std::bit_ceil(size.mib * 1024 * 1024 / std::max(page, 1uz));
             new_max      = std::max(new_max, lowest_max_pages);
 
             if (cache) {
@@ -117,7 +131,7 @@ namespace madbfs
             };
         }
 
-        Await<json::value> handle(ipc::op::SetTTL ttl)
+        AExpect<json::value> handle(ipc::op::SetTTL ttl)
         {
             const auto new_ttl = ttl.sec < 1 ? std::nullopt : Opt<Seconds>{ ttl.sec };
             const auto old_ttl = madbfs.fs().set_ttl(new_ttl);
@@ -129,7 +143,7 @@ namespace madbfs
             };
         }
 
-        Await<json::value> handle(ipc::op::SetTimeout ttl)
+        AExpect<json::value> handle(ipc::op::SetTimeout ttl)
         {
             auto old = std::exchange(madbfs.m_timeout, ttl.sec < 1 ? std::nullopt : Opt<Seconds>{ ttl.sec });
             co_return json::value{
@@ -139,7 +153,7 @@ namespace madbfs
             };
         }
 
-        Await<json::value> handle(ipc::op::SetLogLevel op)
+        AExpect<json::value> handle(ipc::op::SetLogLevel op)
         {
             const auto prev_level = log::get_level();
             const auto new_level  = log::level_from_str(op.lvl).value_or(prev_level);
@@ -153,7 +167,7 @@ namespace madbfs
             };
         }
 
-        Await<json::value> handle(ipc::op::Unmount)
+        AExpect<json::value> handle(ipc::op::Unmount)
         {
             ::fuse_exit(madbfs.m_fuse);
             co_return json::value{ nullptr };
@@ -285,7 +299,7 @@ namespace madbfs
         m_work_thread.join();
     }
 
-    Await<json::value> Madbfs::ipc_handler(ipc::FsOp op)
+    AExpect<json::value> Madbfs::ipc_handler(ipc::FsOp op)
     {
         auto handler = IpcHandler{ *this };
         co_return co_await op.visit([&](auto&& op) { return handler.handle(op); });

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -23,9 +23,11 @@ namespace madbfs
     {
         Await<json::value> handle(ipc::op::Info)
         {
-            const auto page_size     = madbfs.fs().cache().page_size();
-            const auto max_pages     = madbfs.fs().cache().max_pages();
-            const auto current_pages = madbfs.fs().cache().current_pages();
+            const auto& cache = madbfs.fs().cache();
+
+            const auto page_size     = cache.transform(&Cache::page_size).value_or(0);
+            const auto max_pages     = cache.transform(&Cache::max_pages).value_or(0);
+            const auto current_pages = cache.transform(&Cache::current_pages).value_or(0);
             const auto ttl_sec       = madbfs.fs().ttl().transform(&Seconds::count);
             const auto timeout_sec   = madbfs.m_timeout.transform(&Seconds::count);
 
@@ -43,10 +45,14 @@ namespace madbfs
 
         Await<json::value> handle(ipc::op::InvalidateCache)
         {
-            const auto page_size     = madbfs.fs().cache().page_size();
-            const auto current_pages = madbfs.fs().cache().current_pages();
+            auto& cache = madbfs.fs().cache();
 
-            co_await madbfs.fs().cache().invalidate_all();
+            const auto page_size     = cache.transform(&Cache::page_size).value_or(0);
+            const auto current_pages = cache.transform(&Cache::current_pages).value_or(0);
+
+            if (cache) {
+                co_await cache->invalidate_all();
+            }
 
             co_return json::value{ { "size", page_size * current_pages / 1024 / 1024 } };
         }
@@ -59,8 +65,10 @@ namespace madbfs
 
         Await<json::value> handle(ipc::op::SetPageSize size)
         {
-            const auto old_size = madbfs.fs().cache().page_size();
-            const auto old_max  = madbfs.fs().cache().max_pages();
+            auto& cache = madbfs.fs().cache();
+
+            const auto old_size = cache.transform(&Cache::page_size).value_or(0);
+            const auto old_max  = cache.transform(&Cache::max_pages).value_or(0);
 
             auto new_size = std::bit_ceil(size.kib * 1024);
             new_size      = std::clamp(new_size, lowest_page_size, highest_page_size);
@@ -68,8 +76,13 @@ namespace madbfs
             auto new_max = std::bit_ceil(old_max * old_size / new_size);
             new_max      = std::max(new_max, lowest_max_pages);
 
-            co_await madbfs.fs().cache().set_page_size(new_size);
-            co_await madbfs.fs().cache().set_max_pages(new_max);
+            if (cache) {
+                co_await cache->set_page_size(new_size);
+                co_await cache->set_max_pages(new_max);
+            } else {
+                new_size = 0;
+                new_max  = 0;
+            }
 
             co_return json::value{
                 { "page_size",
@@ -83,13 +96,19 @@ namespace madbfs
 
         Await<json::value> handle(ipc::op::SetCacheSize size)
         {
-            const auto page    = madbfs.fs().cache().page_size();
-            const auto old_max = madbfs.fs().cache().max_pages();
+            auto& cache = madbfs.fs().cache();
 
-            auto new_max = std::bit_ceil(size.mib * 1024 * 1024 / page);
+            const auto page    = cache.transform(&Cache::page_size).value_or(0);
+            const auto old_max = cache.transform(&Cache::max_pages).value_or(0);
+
+            auto new_max = std::bit_ceil(size.mib * 1024 * 1024 / (page ? page : 1));
             new_max      = std::max(new_max, lowest_max_pages);
 
-            co_await madbfs.fs().cache().set_max_pages(new_max);
+            if (cache) {
+                co_await cache->set_max_pages(new_max);
+            } else {
+                new_max = 0;
+            }
 
             co_return json::value{
                 { "cache_size",
@@ -205,8 +224,7 @@ namespace madbfs
     Madbfs::Madbfs(
         struct fuse*     fuse,
         args::Connection connection,
-        usize            page_size,
-        usize            max_pages,
+        Opt<Caching>     caching,
         Str              mountpoint,
         Opt<Seconds>     ttl,
         Opt<Seconds>     timeout
@@ -216,7 +234,7 @@ namespace madbfs
         , m_work_guard{ m_async_ctx.get_executor() }
         , m_work_thread{ [this] { work_thread_function(m_async_ctx); } }
         , m_connection{ prepare_connection(m_async_ctx, connection) }
-        , m_fs{ m_connection, page_size, max_pages, ttl }
+        , m_fs{ m_connection, caching, ttl }
         , m_ipc{ create_ipc(m_async_ctx) }
         , m_watchdog_timer{ m_async_ctx }
         , m_reaper_timer{ m_async_ctx }
@@ -290,13 +308,17 @@ namespace madbfs
             if (not ok) {
                 log_i(__func__, "connection is timed out");
                 if (auto res = co_await m_connection.reconnect(); res) {
-                    co_await m_fs.cache().invalidate_fds(false);
+                    if (auto& cache = m_fs.cache(); cache) {
+                        co_await cache->invalidate_fds(false);
+                    }
                     co_await m_connection.start();
                 }
             } else if (not m_connection.is_optimal()) {
                 log_i(__func__, "connection is ok but not optimized. trying to optimize...");
                 if (auto res = co_await m_connection.optimize(); res) {
-                    co_await m_fs.cache().invalidate_fds(false);
+                    if (auto& cache = m_fs.cache(); cache) {
+                        co_await cache->invalidate_fds(false);
+                    }
                     co_await m_connection.start();
                 }
             } else {
@@ -316,15 +338,16 @@ namespace madbfs
                 break;
             }
 
-            co_await m_fs.cache().clean_stale_fds();
+            if (auto& cache = m_fs.cache(); cache) {
+                co_await cache->clean_stale_fds();
+            }
 
             const auto& handles = m_fs.handles();
 
-            auto cap   = handles.size();
-            auto pred  = [](auto&& v) { return std::get<0>(v) == nullptr; };
-            auto empty = static_cast<usize>(sr::count_if(handles.iter(), pred));
+            auto cap   = handles.capacity();
+            auto empty = handles.count_empty();
 
-            log_i(__func__, "file handles [cap={:>04d}|open={:>04d}|unused={:>04d}]", cap, cap - empty, empty);
+            log_i(__func__, "file handles [cap={:>04d}|open={:>04d}|empty={:>04d}]", cap, cap - empty, empty);
         }
     }
 }

--- a/madbfs/src/main.cpp
+++ b/madbfs/src/main.cpp
@@ -35,19 +35,33 @@ try {
         return 1;
     }
 
-    fmt::println("[madbfs] mount '{}' [cache={} MiB, page={} KiB]", opt.serial, opt.cachesize, opt.pagesize);
-    fmt::println("[madbfs] unmount with 'fusermount -u {:?}'", opt.mount);
+    if (opt.caching) {
+        fmt::println(
+            "[madbfs] mount '{}' [cache={} MiB, page={} KiB]",
+            opt.serial,
+            opt.caching->cachesize,
+            opt.caching->pagesize
+        );
+    } else {
+        fmt::println("[madbfs] mount '{}' [no cache]", opt.serial);
+    }
 
     if (opt.log_file != "-") {
-        madbfs::log_i(
-            __func__,
-            "[madbfs] mount '{}' at '{}' with cache size {} MiB and page size {} KiB",
-            opt.serial,
-            opt.mount,
-            opt.cachesize,
-            opt.pagesize
-        );
+        if (opt.caching) {
+            madbfs::log_i(
+                __func__,
+                "[madbfs] mount '{}' at '{}' with cache size {} MiB and page size {} KiB",
+                opt.serial,
+                opt.mount,
+                opt.caching->cachesize,
+                opt.caching->pagesize
+            );
+        } else {
+            madbfs::log_i(__func__, "[madbfs] mount '{}' at '{}' with cache disabled", opt.serial, opt.mount);
+        }
     }
+
+    fmt::println("[madbfs] unmount with 'fusermount -u {:?}'", opt.mount);
 
     if (::setenv("ANDROID_SERIAL", opt.serial.c_str(), 1) < 0) {
         fmt::println(stderr, "error: failed to set env variable 'ANDROID_SERIAL' ({})", strerror(errno));

--- a/madbfs/src/operations.cpp
+++ b/madbfs/src/operations.cpp
@@ -121,14 +121,16 @@ namespace madbfs::operations
             }
         }
 
-        auto cache_size = args->cachesize * 1024 * 1024;
-        auto page_size  = args->pagesize * 1024;
-        auto max_pages  = cache_size / page_size;
-        auto ttl        = args->ttl < 1 ? std::nullopt : Opt<Seconds>{ args->ttl };
-        auto timeout    = args->timeout < 1 ? std::nullopt : Opt<Seconds>{ args->timeout };
-        auto fuse       = ::fuse_get_context()->fuse;
+        auto caching = args->caching.transform([](auto& c) {
+            auto page_size = c.pagesize * 1024;
+            return Caching{ .page_size = page_size, .max_pages = (c.cachesize * 1024 * 1024) / page_size };
+        });
 
-        return new Madbfs{ fuse, args->connection, page_size, max_pages, args->mount, ttl, timeout };
+        auto ttl     = args->ttl < 1 ? std::nullopt : Opt<Seconds>{ args->ttl };
+        auto timeout = args->timeout < 1 ? std::nullopt : Opt<Seconds>{ args->timeout };
+        auto fuse    = ::fuse_get_context()->fuse;
+
+        return new Madbfs{ fuse, args->connection, caching, args->mount, ttl, timeout };
     }
 
     void destroy(void* private_data) noexcept

--- a/madbfs/src/operations.cpp
+++ b/madbfs/src/operations.cpp
@@ -162,13 +162,16 @@ namespace madbfs::operations
 
         std::memset(stbuf, 0, sizeof(struct stat));
 
+        const auto default_page_size = 64 * 1024;    // use minimum page size
+        auto page_size = get_data().fs().cache().transform(&Cache::page_size).value_or(default_page_size);
+
         stbuf->st_ino     = static_cast<ino_t>(id.inner());
         stbuf->st_mode    = stat.mode;
         stbuf->st_nlink   = stat.links;
         stbuf->st_uid     = stat.uid;
         stbuf->st_gid     = stat.gid;
         stbuf->st_size    = stat.size;
-        stbuf->st_blksize = static_cast<blksize_t>(get_data().fs().cache().page_size());
+        stbuf->st_blksize = static_cast<blksize_t>(page_size);
         stbuf->st_blocks  = (stbuf->st_size + 511) / 512;    // strictly in 512 B units [read stat(3)]
         stbuf->st_atim    = stat.atime;
         stbuf->st_mtim    = stat.mtime;

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -52,7 +52,7 @@ READDIR_BIG_SIZE = 200
 DEFAULT_PAGE_SIZE = 128  # in KiB
 DEFAULT_CACHE_SIZE = 256  # in MiB
 DEFAULT_TTL = 60  # in seconds
-DEFAULT_TIMEOUT = 2 # in seconds
+DEFAULT_TIMEOUT = 2  # in seconds
 DEFAULT_LOG_LEVEL = "debug"  # on this test only
 
 logger = logging.getLogger(__name__)
@@ -66,7 +66,29 @@ class Environ:
     test_dir: Path
     log_path: Path
     mount_cmd: list[str]
-    server: bool
+
+
+@dataclass
+class Case:
+    use_server: bool
+    use_cache: bool
+
+    @staticmethod
+    def permutation():
+        return [
+            Case(True, True),
+            Case(True, False),
+            Case(False, True),
+            Case(False, False),
+        ]
+
+    @staticmethod
+    def with_server_only():
+        return [Case(True, True), Case(True, False)]
+
+    @staticmethod
+    def no_server_only():
+        return [Case(False, True), Case(False, False)]
 
 
 class Protocol:
@@ -108,9 +130,8 @@ class Protocol:
         return data, packet_count
 
 
-@pytest.fixture(params=[True, False])
-# @pytest.fixture(params=[True])
-def environ(request):
+@pytest.fixture(params=Case.permutation())
+def environ(request) -> tuple[Environ, Case]:
     serial = os.environ.get("ANDROID_SERIAL")
     if serial is None:
         pytest.fail("test requires ANDROID_SERIAL environment variable to be set")
@@ -123,7 +144,7 @@ def environ(request):
     abi = abi.stdout.decode("utf-8").strip()
 
     server_path = SERVER_PATH.parent / f"{SERVER_PATH.name}-{abi}"
-    if request.param and not server_path.exists():
+    if request.param.use_server and not server_path.exists():
         pytest.fail(f"server path '{server_path}' doesn't exists. compile it first!")
 
     mount_point = CURRENT_DIR / "mount"
@@ -143,17 +164,21 @@ def environ(request):
         "-f",
         f"--log-file={log_path}",
         f"--log-level={DEFAULT_LOG_LEVEL}",
-        f"--server={server_path}" if request.param else "--no-server",
+        f"--server={server_path}" if request.param.use_server else "--no-server",
     ]
+    if not request.param.use_cache:
+        mount_cmd.append("--no-cache")
 
-    return Environ(
-        abi=abi,
-        serial=serial,
-        mount_point=mount_point,
-        test_dir=test_dir,
-        log_path=log_path,
-        mount_cmd=mount_cmd,
-        server=request.param,
+    return (
+        Environ(
+            abi=abi,
+            serial=serial,
+            mount_point=mount_point,
+            test_dir=test_dir,
+            log_path=log_path,
+            mount_cmd=mount_cmd,
+        ),
+        request.param,
     )
 
 
@@ -614,9 +639,9 @@ def tst_open_rename(work_dir: Path):
 
 
 # first args is there just for symmetry, it's unused
-def tst_ipc(work_dir: str, serial: str, server_used: bool):
+def tst_ipc(_: str, serial: str, use_server: bool, use_cache: bool):
     version_re = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
-    connection = "proxy" if server_used else "adb"
+    connection = "proxy" if use_server else "adb"
     timeout = DEFAULT_TIMEOUT
 
     with ipc_connect(serial) as sock:
@@ -651,10 +676,14 @@ def tst_ipc(work_dir: str, serial: str, server_used: bool):
         assert resp["value"]["log_level"] == DEFAULT_LOG_LEVEL
         assert resp["value"]["ttl"] == DEFAULT_TTL
         assert resp["value"]["timeout"] == timeout
-        assert resp["value"]["page_size"] == DEFAULT_PAGE_SIZE
-        assert resp["value"]["cache_size"]
-        assert resp["value"]["cache_size"]["max"] == DEFAULT_CACHE_SIZE
-        assert isinstance(resp["value"]["cache_size"]["current"], int)
+        if use_cache:
+            assert resp["value"]["cache"] is not None
+            assert resp["value"]["cache"]["page_size"] == DEFAULT_PAGE_SIZE
+            assert resp["value"]["cache"]["cache_size"]
+            assert resp["value"]["cache"]["cache_size"]["max"] == DEFAULT_CACHE_SIZE
+            assert isinstance(resp["value"]["cache"]["cache_size"]["current"], int)
+        else:
+            assert resp["value"]["cache"] is None
 
     with ipc_connect(serial) as sock:
         Protocol.send(sock, json.dumps({"op": "invalidate_cache"}))
@@ -662,9 +691,13 @@ def tst_ipc(work_dir: str, serial: str, server_used: bool):
         assert resp is not None
         logger.info(resp)
         resp = json.loads(resp)
-        assert resp["status"] == "success"
-        assert resp["value"]
-        assert isinstance(resp["value"]["size"], int)
+        if use_cache:
+            assert resp["status"] == "success"
+            assert resp["value"]
+            assert isinstance(resp["value"]["size"], int)
+        else:
+            assert resp["status"] == "error"
+            assert resp["value"] == os.strerror(errno.EOPNOTSUPP)
 
     with ipc_connect(serial) as sock:
         Protocol.send(sock, json.dumps({"op": "set_page_size", "value": 256}))
@@ -672,14 +705,18 @@ def tst_ipc(work_dir: str, serial: str, server_used: bool):
         assert resp is not None
         logger.info(resp)
         resp = json.loads(resp)
-        assert resp["status"] == "success"
-        assert resp["value"]
-        assert resp["value"]["page_size"]
-        assert resp["value"]["page_size"]["old"] == DEFAULT_PAGE_SIZE
-        assert resp["value"]["page_size"]["new"] == 256
-        assert resp["value"]["cache_size"]
-        assert isinstance(resp["value"]["cache_size"]["old"], int)
-        assert isinstance(resp["value"]["cache_size"]["new"], int)
+        if use_cache:
+            assert resp["status"] == "success"
+            assert resp["value"]
+            assert resp["value"]["page_size"]
+            assert resp["value"]["page_size"]["old"] == DEFAULT_PAGE_SIZE
+            assert resp["value"]["page_size"]["new"] == 256
+            assert resp["value"]["cache_size"]
+            assert isinstance(resp["value"]["cache_size"]["old"], int)
+            assert isinstance(resp["value"]["cache_size"]["new"], int)
+        else:
+            assert resp["status"] == "error"
+            assert resp["value"] == os.strerror(errno.EOPNOTSUPP)
 
     with ipc_connect(serial) as sock:
         Protocol.send(sock, json.dumps({"op": "set_cache_size", "value": 128}))
@@ -687,11 +724,15 @@ def tst_ipc(work_dir: str, serial: str, server_used: bool):
         assert resp is not None
         logger.info(resp)
         resp = json.loads(resp)
-        assert resp["status"] == "success"
-        assert resp["value"]
-        assert resp["value"]["cache_size"]
-        assert resp["value"]["cache_size"]["old"] == DEFAULT_CACHE_SIZE
-        assert resp["value"]["cache_size"]["new"] == 128
+        if use_cache:
+            assert resp["status"] == "success"
+            assert resp["value"]
+            assert resp["value"]["cache_size"]
+            assert resp["value"]["cache_size"]["old"] == DEFAULT_CACHE_SIZE
+            assert resp["value"]["cache_size"]["new"] == (128 if use_cache else 0)
+        else:
+            assert resp["status"] == "error"
+            assert resp["value"] == os.strerror(errno.EOPNOTSUPP)
 
     with ipc_connect(serial) as sock:
         Protocol.send(sock, json.dumps({"op": "set_ttl", "value": 20}))
@@ -745,11 +786,13 @@ def test_filesystem(environ):
     test_dir: Path
     log_file: Path
     cmd_base: list[str]
-    server: bool
+    use_server: bool
+    use_cache: bool
 
-    serial, abi, mount_point, test_dir, log_file, cmd_base, server = astuple(environ)
+    serial, abi, mount_point, test_dir, log_file, cmd_base = astuple(environ[0])
+    use_server, use_cache = astuple(environ[1])
 
-    logger.info(f"test is [running serial={serial}, abi={abi}, server={server}]")
+    logger.info(f"[serial={serial}, abi={abi}, server={use_server}, cache={use_cache}]")
 
     cmd = cmd_base + [f"--serial={serial}", str(mount_point)]
     proc = Popen(cmd, stdout=PIPE, universal_newlines=True)
@@ -793,13 +836,15 @@ def test_filesystem(environ):
         call(tst_unlink)
         call(tst_symlink)
         call(tst_chown)
-        call(tst_utimens, 1000 if server else 1000000000)  # tolerance in nanoseconds
+        call(
+            tst_utimens, 1000 if use_server else 1000000000
+        )  # tolerance in nanoseconds
         call(tst_link)
         call(tst_truncate_path)
         call(tst_truncate_fd)
         call(tst_open_unlink)
         call(tst_open_rename)
-        call(tst_ipc, serial, server)
+        call(tst_ipc, serial, use_server, use_cache)
     except:
         # NOTE: if tests are failing, the work_dir might not be cleaned up correctly. I
         # won't clean them up here since I might want to inspect the file in the work_dir

--- a/test/test_ipc.cpp
+++ b/test/test_ipc.cpp
@@ -23,7 +23,7 @@ namespace net   = madbfs::net;
 using madbfs::Await, madbfs::AExpect;
 using namespace madbfs::aliases;
 
-Await<boost::json::value> server_handler(ipc::FsOp op)
+AExpect<boost::json::value> server_handler(ipc::FsOp op)
 {
     co_return boost::json::value{
         { "type", op.visit([]<typename Op>(Op) { return ut::reflection::type_name<Op>(); }) }

--- a/test/test_tree.cpp
+++ b/test/test_tree.cpp
@@ -222,7 +222,7 @@ int main()
         auto guard      = madbfs::net::make_work_guard(context);
         auto thread     = std::jthread{ [&] { context.run(); } };
         auto connection = madbfs::Connection{ context, mock::dummy_strategy };
-        auto tree       = Filesystem{ connection, 64 * 1024, 1024, std::nullopt };
+        auto tree       = Filesystem{ connection, std::nullopt, std::nullopt };
 
         using madbfs::path::operator""_path;
 


### PR DESCRIPTION
This implementation is basically a direct I/O. There is no caching for file content as well as the file handle/descriptor. User can enable this no-cache mode by providing `--no-cache` program argument.

This change also updates IPC response as now the cache is optional, some operation can return a failure: `invalidate_cache`, `set_cache_size`, and `set_page_size`. The `info` command response is modified as well. It now has new property, `cache`, that contains previously `page_size` and `cache_size` property; both are now contained in this child object. `cache` will have `null` value if the cache is not active though.