### PR TITLE
Implement mounting subdirectory

### DIFF
--- a/madbfs/include/madbfs/args.hpp
+++ b/madbfs/include/madbfs/args.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "madbfs/path.hpp"
+
 #include <madbfs-common/async/async.hpp>
 #include <madbfs-common/log.hpp>
 #include <madbfs-common/util/var_wrapper.hpp>
@@ -23,6 +25,7 @@ namespace madbfs::args
     struct MadbfsOpt
     {
         const char* serial     = nullptr;
+        const char* root       = nullptr;
         const char* server     = nullptr;
         const char* log_level  = nullptr;
         const char* log_file   = nullptr;
@@ -38,6 +41,7 @@ namespace madbfs::args
         ~MadbfsOpt()
         {
             ::free((void*)serial);
+            ::free((void*)root);
             ::free((void*)server);
             ::free((void*)log_level);
             ::free((void*)log_file);
@@ -71,14 +75,15 @@ namespace madbfs::args
      */
     struct ParsedOpt
     {
-        String       mount;
-        String       serial;
-        Connection   connection;
-        Opt<Caching> caching;
-        log::Level   log_level;
-        String       log_file;
-        i32          ttl;
-        i32          timeout;
+        String        mount;
+        String        serial;
+        path::PathBuf root;
+        Connection    connection;
+        Opt<Caching>  caching;
+        log::Level    log_level;
+        String        log_file;
+        i32           ttl;
+        i32           timeout;
     };
 
     /**
@@ -111,6 +116,7 @@ namespace madbfs::args
     static constexpr auto madbfs_opt_spec = std::to_array<fuse_opt>({
         // clang-format off
         { "--serial=%s",     offsetof(MadbfsOpt, serial),     true },
+        { "--root=%s",       offsetof(MadbfsOpt, root),       true },
         { "--server=%s",     offsetof(MadbfsOpt, server),     true },
         { "--log-level=%s",  offsetof(MadbfsOpt, log_level),  true },
         { "--log-file=%s",   offsetof(MadbfsOpt, log_file),   true },

--- a/madbfs/include/madbfs/madbfs.hpp
+++ b/madbfs/include/madbfs/madbfs.hpp
@@ -3,6 +3,7 @@
 #include "madbfs/args.hpp"
 #include "madbfs/connection.hpp"
 #include "madbfs/filesystem.hpp"
+#include "madbfs/path.hpp"
 
 #include <madbfs-common/ipc.hpp>
 
@@ -27,6 +28,7 @@ namespace madbfs
             struct fuse*     fuse,
             args::Connection connection,
             Opt<Caching>     caching,
+            path::Path       custom_root,
             Str              mount_point,
             Opt<Seconds>     ttl,
             Opt<Seconds>     timeout
@@ -39,6 +41,19 @@ namespace madbfs
 
         Madbfs(const Madbfs&)            = delete;
         Madbfs& operator=(const Madbfs&) = delete;
+
+        /**
+         * @brief Crate a new real file path on device.
+         *
+         * @param path Path to file (raw from FUSE).
+         *
+         * @return The path prepended with custom root, or `Errc::operation_not_supported`
+         *
+         * This function prepends custom root path into the path.
+         *
+         * TODO: add mechanism that cache the PathBuf so no repeated allocations.
+         */
+        Expect<path::PathBuf> create_path(const char* path);
 
         Filesystem&     fs() { return m_fs; }
         async::Context& ctx() { return m_async_ctx; }
@@ -106,7 +121,8 @@ namespace madbfs
         async::Timer    m_reaper_timer;
         net::signal_set m_signal;
 
-        String       m_mountpoint;
-        Opt<Seconds> m_timeout;
+        path::PathBuf m_root;    // custom root for mounting subdirectory
+        String        m_mountpoint;
+        Opt<Seconds>  m_timeout;
     };
 }

--- a/madbfs/src/args.cpp
+++ b/madbfs/src/args.cpp
@@ -153,6 +153,10 @@ namespace madbfs::args
             "    --serial=<str>         serial number of the device to mount\n"
             "                             (you can omit this [detection is similar to adb])\n"
             "                             (will prompt if more than one device exists)\n"
+            "    --root=<path>          directory to mount on device as root of the filesystem\n"
+            "                             (by default madbfs mounts the root path of the device)\n"
+            "                             (the path must be absolute and points to an existing path)\n"
+            "                             (if the path is a symlink, it will be resolved first)\n"
             "    --server=<path>        path to server file\n"
             "                             (if omitted will search the file automatically)\n"
             "                             (must have the same arch as your phone)\n"
@@ -307,6 +311,35 @@ namespace madbfs::args
             co_return ParseResult{ 1 };
         }
 
+        auto root = path::PathBuf{};
+        {
+            auto path = path::create_buf(madbfs_opt.root ? madbfs_opt.root : "/");
+            if (not path) {
+                fmt::println(stderr, "[madbfs] root path is not valid");
+                ::fuse_opt_free_args(&args);
+                co_return ParseResult{ 1 };
+            }
+
+            auto str = fmt::format("\"{}\"", path->str());
+
+            if (auto is_dir = co_await cmd::exec({ "adb", "shell", "test", "-d", str }); not is_dir) {
+                fmt::println(stderr, "[madbfs] root path is not a directory or not exists");
+                ::fuse_opt_free_args(&args);
+                co_return ParseResult{ 1 };
+            }
+
+            if (auto is_link = co_await cmd::exec({ "adb", "shell", "test", "-L", str }); not is_link) {
+                root = std::move(path).value();
+            } else if (auto link = co_await cmd::exec({ "adb", "shell", "readlink", "-ne", str }); not link) {
+                fmt::println(stderr, "[madbfs] failed to read link");
+                ::fuse_opt_free_args(&args);
+                co_return ParseResult{ 1 };
+            } else {
+                root = path::create_buf(std::move(link).value()).value();
+                fmt::println("[madbfs] root resolved: {:?} -> {:?}", path->str(), root);
+            }
+        }
+
         auto port       = static_cast<u16>(madbfs_opt.port);
         auto connection = Connection{ connection::AdbOnly{} };
 
@@ -377,6 +410,7 @@ namespace madbfs::args
             .opt = {
                 .mount      = std::move(mountpoint),
                 .serial     = madbfs_opt.serial,
+                .root       = std::move(root),
                 .connection = connection,
                 .caching    = caching,
                 .log_level  = log_level.value(),

--- a/madbfs/src/cmd.cpp
+++ b/madbfs/src/cmd.cpp
@@ -203,7 +203,7 @@ namespace madbfs::cmd
         auto ret = co_await proc.async_wait();
         if (check and ret != 0) {
             auto errmsg = not err.empty() ? util::strip(err) : util::strip(out);
-            log_i(__func__, "non-zero command status ({}) {}: err: [{}]", ret, cmd, errmsg);
+            log_t(__func__, "non-zero command status ({}) {}: err: [{}]", ret, cmd, errmsg);
             co_return Unexpect{ to_errc(parse_stderr(errmsg)) };
         }
 

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -239,6 +239,7 @@ namespace madbfs
         struct fuse*     fuse,
         args::Connection connection,
         Opt<Caching>     caching,
+        path::Path       custom_root,
         Str              mountpoint,
         Opt<Seconds>     ttl,
         Opt<Seconds>     timeout
@@ -253,6 +254,7 @@ namespace madbfs
         , m_watchdog_timer{ m_async_ctx }
         , m_reaper_timer{ m_async_ctx }
         , m_signal{ m_async_ctx, SIGINT, SIGTERM }
+        , m_root{ custom_root.owned() }
         , m_mountpoint{ mountpoint }
         , m_timeout{ timeout }
     {
@@ -297,6 +299,19 @@ namespace madbfs
         m_work_guard.reset();
         m_async_ctx.stop();
         m_work_thread.join();
+    }
+
+    Expect<path::PathBuf> Madbfs::create_path(const char* path)
+    {
+        if (m_root.is_root()) {
+            return ok_or(path::create_buf(path), Errc::operation_not_supported);
+        }
+
+        auto str = String{ m_root.str() };
+        str.ends_with('/') ? void() : str.push_back('/');
+        str.append(path);
+
+        return ok_or(path::create_buf(std::move(str)), Errc::operation_not_supported);
     }
 
     AExpect<json::value> Madbfs::ipc_handler(ipc::FsOp op)

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -35,6 +35,7 @@ namespace madbfs
 
                 co_return json::value{
                     { "connection", madbfs.m_connection.name() },
+                    { "root", madbfs.m_root.str() },
                     { "log_level", log::level_to_str(log::get_level()) },
                     { "ttl", ttl_sec },
                     { "timeout", timeout_sec },
@@ -47,6 +48,7 @@ namespace madbfs
             } else {
                 co_return json::value{
                     { "connection", madbfs.m_connection.name() },
+                    { "root", madbfs.m_root.str() },
                     { "log_level", log::level_to_str(log::get_level()) },
                     { "ttl", ttl_sec },
                     { "timeout", timeout_sec },

--- a/madbfs/src/main.cpp
+++ b/madbfs/src/main.cpp
@@ -37,27 +37,35 @@ try {
 
     if (opt.caching) {
         fmt::println(
-            "[madbfs] mount '{}' [cache={} MiB, page={} KiB]",
+            "[madbfs] mount '{}@{}' [cache={} MiB, page={} KiB]",
             opt.serial,
+            opt.root,
             opt.caching->cachesize,
             opt.caching->pagesize
         );
     } else {
-        fmt::println("[madbfs] mount '{}' [no cache]", opt.serial);
+        fmt::println("[madbfs] mount '{}@{}' [no cache]", opt.serial, opt.root);
     }
 
     if (opt.log_file != "-") {
         if (opt.caching) {
             madbfs::log_i(
                 __func__,
-                "[madbfs] mount '{}' at '{}' with cache size {} MiB and page size {} KiB",
+                "[madbfs] mount '{}@{}' at '{}' with cache size {} MiB and page size {} KiB",
                 opt.serial,
+                opt.root,
                 opt.mount,
                 opt.caching->cachesize,
                 opt.caching->pagesize
             );
         } else {
-            madbfs::log_i(__func__, "[madbfs] mount '{}' at '{}' with cache disabled", opt.serial, opt.mount);
+            madbfs::log_i(
+                __func__,
+                "[madbfs] mount '{}@{}' at '{}' with cache disabled",
+                opt.serial,
+                opt.root,
+                opt.mount
+            );
         }
     }
 

--- a/madbfs/src/operations.cpp
+++ b/madbfs/src/operations.cpp
@@ -130,7 +130,7 @@ namespace madbfs::operations
         auto timeout = args->timeout < 1 ? std::nullopt : Opt<Seconds>{ args->timeout };
         auto fuse    = ::fuse_get_context()->fuse;
 
-        return new Madbfs{ fuse, args->connection, caching, path::Path{}, args->mount, ttl, timeout };
+        return new Madbfs{ fuse, args->connection, caching, args->root, args->mount, ttl, timeout };
     }
 
     void destroy(void* private_data) noexcept

--- a/madbfs/src/operations.cpp
+++ b/madbfs/src/operations.cpp
@@ -130,7 +130,7 @@ namespace madbfs::operations
         auto timeout = args->timeout < 1 ? std::nullopt : Opt<Seconds>{ args->timeout };
         auto fuse    = ::fuse_get_context()->fuse;
 
-        return new Madbfs{ fuse, args->connection, caching, args->mount, ttl, timeout };
+        return new Madbfs{ fuse, args->connection, caching, path::Path{}, args->mount, ttl, timeout };
     }
 
     void destroy(void* private_data) noexcept
@@ -153,7 +153,7 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?}", path);
 
-        auto named_stat = ok_or(path::create(path), Errc::operation_not_supported).and_then([](path::Path p) {
+        auto named_stat = get_data().create_path(path).and_then([](path::PathBuf p) {
             return invoke_fs(&Filesystem::getattr, p);
         });
         if (not named_stat.has_value()) {
@@ -186,8 +186,9 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?}", path);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return invoke_fs(&Filesystem::readlink, p); })
+        return get_data()
+            .create_path(path)
+            .and_then([](path::PathBuf p) { return invoke_fs(&Filesystem::readlink, p); })
             .and_then([&](Str target) -> Expect<void> {
                 if (target.size() < 1) {
                     return Unexpect{ Errc::invalid_argument };
@@ -221,8 +222,9 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?}", path);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([=](path::Path p) { return invoke_fs(&Filesystem::mknod, p, mode, dev); })
+        return get_data()
+            .create_path(path)
+            .and_then([=](path::PathBuf p) { return invoke_fs(&Filesystem::mknod, p, mode, dev); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -231,8 +233,9 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?}", path);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([=](path::Path p) { return invoke_fs(&Filesystem::mkdir, p, mode | S_IFDIR); })
+        return get_data()
+            .create_path(path)
+            .and_then([=](path::PathBuf p) { return invoke_fs(&Filesystem::mkdir, p, mode | S_IFDIR); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -241,8 +244,9 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?}", path);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return invoke_fs(&Filesystem::unlink, p); })
+        return get_data()
+            .create_path(path)
+            .and_then([](path::PathBuf p) { return invoke_fs(&Filesystem::unlink, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -251,8 +255,9 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?}", path);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([](path::Path p) { return invoke_fs(&Filesystem::rmdir, p); })
+        return get_data()
+            .create_path(path)
+            .and_then([](path::PathBuf p) { return invoke_fs(&Filesystem::rmdir, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -262,8 +267,8 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?} -> {:?} [flags={}]", from, to, flags);
 
-        auto from_path = path::create(from);
-        auto to_path   = path::create(to);
+        auto from_path = get_data().create_path(from);
+        auto to_path   = get_data().create_path(to);
 
         if (not from_path.has_value()) {
             return fuse_err(__func__, from)(Errc::operation_not_supported);
@@ -281,8 +286,9 @@ namespace madbfs::operations
     {
         log_i(__func__, "[size={}] {:?}", size, path);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::truncate, p, size); })
+        return get_data()
+            .create_path(path)
+            .and_then([&](path::PathBuf p) { return invoke_fs(&Filesystem::truncate, p, size); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -291,8 +297,9 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?} [flags={:#08o}]", path, fi->flags);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::open, p, fi->flags); })
+        return get_data()
+            .create_path(path)
+            .and_then([&](path::PathBuf p) { return invoke_fs(&Filesystem::open, p, fi->flags); })
             .transform([&](u64 fd) { fi->fh = fd; })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
@@ -343,8 +350,9 @@ namespace madbfs::operations
 
         const auto fill = [&](const char* name) { filler(buf, name, nullptr, 0, FUSE_FILL_DIR_PLUS); };
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::readdir, p, fill); })
+        return get_data()
+            .create_path(path)
+            .and_then([&](path::PathBuf p) { return invoke_fs(&Filesystem::readdir, p, fill); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -358,8 +366,9 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?}", path);
 
-        return ok_or(path::create(path), Errc::operation_not_supported)
-            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::utimens, p, tv[0], tv[1]); })
+        return get_data()
+            .create_path(path)
+            .and_then([&](path::PathBuf p) { return invoke_fs(&Filesystem::utimens, p, tv[0], tv[1]); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }

--- a/test/test_filesystem.py
+++ b/test/test_filesystem.py
@@ -72,23 +72,29 @@ class Environ:
 class Case:
     use_server: bool
     use_cache: bool
+    custom_root: bool
+    name: str
 
     @staticmethod
     def permutation():
         return [
-            Case(True, True),
-            Case(True, False),
-            Case(False, True),
-            Case(False, False),
+            Case(True, True, True, "case1"),
+            Case(True, True, False, "case2"),
+            Case(True, False, True, "case3"),
+            Case(True, False, False, "case4"),
+            Case(False, True, True, "case5"),
+            Case(False, True, False, "case6"),
+            Case(False, False, True, "case7"),
+            Case(False, False, False, "case8"),
         ]
 
     @staticmethod
     def with_server_only():
-        return [Case(True, True), Case(True, False)]
+        return Case.permutation()[:4]
 
     @staticmethod
     def no_server_only():
-        return [Case(False, True), Case(False, False)]
+        return Case.permutation()[4:]
 
 
 class Protocol:
@@ -156,8 +162,7 @@ def environ(request) -> tuple[Environ, Case]:
     elif len(os.listdir(mount_point)) > 0:
         pytest.fail(f"mount point {mount_point} is not empty")
 
-    test_dir = mount_point / "data/local/tmp"  # testing on /sdcard is risky...
-    log_path = CURRENT_DIR / "test.log"
+    log_path = CURRENT_DIR / "log" / f"test-{request.param.name}.log"
 
     mount_cmd = [
         BINARY_PATH,
@@ -166,8 +171,16 @@ def environ(request) -> tuple[Environ, Case]:
         f"--log-level={DEFAULT_LOG_LEVEL}",
         f"--server={server_path}" if request.param.use_server else "--no-server",
     ]
+
     if not request.param.use_cache:
         mount_cmd.append("--no-cache")
+    if request.param.custom_root:
+        mount_cmd.append("--root=/data/local/tmp")
+
+    # testing on other directory is risky...
+    test_dir = mount_point
+    if not request.param.custom_root:
+        test_dir = test_dir / "data/local/tmp"
 
     return (
         Environ(
@@ -788,11 +801,14 @@ def test_filesystem(environ):
     cmd_base: list[str]
     use_server: bool
     use_cache: bool
+    custom_root: bool
 
     serial, abi, mount_point, test_dir, log_file, cmd_base = astuple(environ[0])
-    use_server, use_cache = astuple(environ[1])
+    use_server, use_cache, custom_root, _ = astuple(environ[1])
 
-    logger.info(f"[serial={serial}, abi={abi}, server={use_server}, cache={use_cache}]")
+    logger.info(
+        f"[serial={serial}, abi={abi}, server={use_server}, cache={use_cache}, custom_root={custom_root}, log={log_file}]"
+    )
 
     cmd = cmd_base + [f"--serial={serial}", str(mount_point)]
     proc = Popen(cmd, stdout=PIPE, universal_newlines=True)
@@ -812,6 +828,7 @@ def test_filesystem(environ):
         logger.info(f"filesystem is mounted at {mount_point}")
 
         work_dir = test_dir / "testing"
+
         if work_dir.exists():
             shutil.rmtree(work_dir)
         work_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
Implementing feature request from issue: #18 

- Add new member on `Madbfs` storing custom root point of the filesystem
- All path paths from FUSE now prepended with the custom root point (via `Madbfs::create_path()`)
- Add new program argument `--root` for mounting subdirectory
- Add new field to IPC `info` command result