### PR TITLE
Eliminate allocation on path translation when mounting subdirectory

### DIFF
--- a/madbfs/include/madbfs/filesystem.hpp
+++ b/madbfs/include/madbfs/filesystem.hpp
@@ -105,6 +105,11 @@ namespace madbfs
         Expect<void> symlink(path::Path path, Str target);
 
         /**
+         * @brief Initialize root directory by getting its stat early.
+         */
+        AExpect<void> initialize_root();
+
+        /**
          * @brief Shut down the filesystem and stop every async operation.
          *
          * Call this before destructor. This is needed to do proper flushing for the `Cache`.

--- a/madbfs/include/madbfs/madbfs.hpp
+++ b/madbfs/include/madbfs/madbfs.hpp
@@ -47,7 +47,7 @@ namespace madbfs
          *
          * @param path Path to file (raw from FUSE).
          *
-         * @return The path prepended with custom root, or `Errc::operation_not_supported`
+         * @return The path prepended with custom root, or `Errc::invalid_argument`
          *
          * This function prepends custom root path into the path.
          *

--- a/madbfs/include/madbfs/madbfs.hpp
+++ b/madbfs/include/madbfs/madbfs.hpp
@@ -43,17 +43,32 @@ namespace madbfs
         Madbfs& operator=(const Madbfs&) = delete;
 
         /**
-         * @brief Crate a new real file path on device.
+         * @brief Create a new real file path on device (by prepending the path with custom root).
          *
          * @param path Path to file (raw from FUSE).
          *
          * @return The path prepended with custom root, or `Errc::invalid_argument`
          *
-         * This function prepends custom root path into the path.
+         * @warning This function caches the string and components of the path using TLS scratch buffer.
+         * The produced path only valid until the next call to this function. Previos path produced by this
+         * function will be overwritten by the path used on latest call to this function.
          *
-         * TODO: add mechanism that cache the PathBuf so no repeated allocations.
+         * Use the `create_path2()` for 2 simultaneous path creation, there are two scratch buffer in that
+         * function.
          */
-        Expect<path::PathBuf> create_path(const char* path);
+        Expect<path::Path> create_path(const char* path);
+
+        /**
+         * @brief Create two new real file path on device (by prepending the path with custom root).
+         *
+         * @param path1 Path to file (raw from FUSE).
+         * @param path2 Path to file (raw from FUSE).
+         *
+         * @return The path prepended with custom root, or `Errc::invalid_argument`
+         *
+         * The same warning as `create_path()` applies.
+         */
+        Expect<Array<path::Path, 2>> create_path2(const char* path1, const char* path2);
 
         Filesystem&     fs() { return m_fs; }
         async::Context& ctx() { return m_async_ctx; }

--- a/madbfs/include/madbfs/path.hpp
+++ b/madbfs/include/madbfs/path.hpp
@@ -33,7 +33,8 @@ namespace madbfs::path
     {
     public:
         friend class PathBuf;
-        friend Opt<SemiPath> create(Str path);
+        friend Opt<SemiPath> create(Str);
+        friend Opt<Path>     create_with(Vec<Slice>&, Str);
 
         /**
          * @brief Default construct a path.
@@ -268,6 +269,15 @@ namespace madbfs::path
      * @param path_str The path to create from.
      */
     Opt<PathBuf> create_buf(String&& path_str);
+
+    /**
+     * @brief Create a Path from a string and use the buf provided as the components storage.
+     *
+     * @param path Path string.
+     *
+     * The rule is the same as `create()`. `comps_buf` will be cleared only on success.
+     */
+    Opt<Path> create_with(Vec<Slice>& comps_buf, Str path);
 
     /**
      * @brief Resolve path relative to parent.

--- a/madbfs/include/madbfs/path.hpp
+++ b/madbfs/include/madbfs/path.hpp
@@ -58,27 +58,14 @@ namespace madbfs::path
          * This operation returns a directory path as if you do `dirname <path>` command. Use `parent_path()`
          * member function if you want the resulting path as `Path` instead of plain string.
          */
-        Str parent() const
-        {
-            if (is_root() or m_components.size() == 1) {
-                return "/";
-            }
-
-            const auto parent = m_components[m_components.size() - 2];
-            const auto size   = parent.offset + parent.size;
-
-            return { m_path.data(), size };
-        }
+        Str parent() const;
 
         /**
          * @brief Create a `Path` that points to parent as its basename.
          *
          * @return New Path.
          */
-        Path parent_path() const
-        {
-            return is_root() ? *this : Path{ parent(), { m_components.begin(), m_components.size() - 1 } };
-        }
+        Path parent_path() const;
 
         /**
          * @brief Get the full path as string.
@@ -163,27 +150,14 @@ namespace madbfs::path
          * This operation returns a directory path as if you do `dirname <path>` command. Use `parent_path()`
          * member function if you want the resulting path as `Path` instead of plain string.
          */
-        Str parent() const
-        {
-            if (is_root() or m_components.size() == 1) {
-                return "/";
-            }
-
-            const auto parent = m_components[m_components.size() - 2];
-            const auto size   = parent.offset + parent.size;
-
-            return { m_path.data(), size };
-        }
+        Str parent() const;
 
         /**
          * @brief Create a `Path` that points to parent as its basename.
          *
          * @return New Path.
          */
-        Path parent_path() const
-        {
-            return is_root() ? *this : Path{ parent(), { m_components.begin(), m_components.size() - 1 } };
-        }
+        Path parent_path() const;
 
         /**
          * @brief Get the full path as string.

--- a/madbfs/src/args.cpp
+++ b/madbfs/src/args.cpp
@@ -312,32 +312,31 @@ namespace madbfs::args
         }
 
         auto root = path::PathBuf{};
-        {
-            auto path = path::create_buf(madbfs_opt.root ? madbfs_opt.root : "/");
-            if (not path) {
+        if (madbfs_opt.root) {
+            auto path = String{ madbfs_opt.root };
+            if (path.empty() or path.front() != '/') {
                 fmt::println(stderr, "[madbfs] root path is not valid");
                 ::fuse_opt_free_args(&args);
                 co_return ParseResult{ 1 };
             }
 
-            auto str = fmt::format("\"{}\"", path->str());
+            auto quoted = fmt::format("\"{}\"", path);
 
-            if (auto is_dir = co_await cmd::exec({ "adb", "shell", "test", "-d", str }); not is_dir) {
+            if (auto is_dir = co_await cmd::exec({ "adb", "shell", "test", "-d", quoted }); not is_dir) {
                 fmt::println(stderr, "[madbfs] root path is not a directory or not exists");
                 ::fuse_opt_free_args(&args);
                 co_return ParseResult{ 1 };
             }
 
-            if (auto is_link = co_await cmd::exec({ "adb", "shell", "test", "-L", str }); not is_link) {
-                root = std::move(path).value();
-            } else if (auto link = co_await cmd::exec({ "adb", "shell", "readlink", "-ne", str }); not link) {
-                fmt::println(stderr, "[madbfs] failed to read link");
+            auto real = co_await cmd::exec({ "adb", "shell", "realpath", quoted });
+            if (not real) {
+                fmt::println(stderr, "[madbfs] failed to resolve path: {}", err_msg(real.error()));
                 ::fuse_opt_free_args(&args);
                 co_return ParseResult{ 1 };
-            } else {
-                root = path::create_buf(std::move(link).value()).value();
-                fmt::println("[madbfs] root resolved: {:?} -> {:?}", path->str(), root);
             }
+
+            root = path::create_buf(String{ util::strip(*real) }).value();
+            fmt::println("[madbfs] root resolved: {:?} -> {:?}", path, root);
         }
 
         auto port       = static_cast<u16>(madbfs_opt.port);

--- a/madbfs/src/filesystem.cpp
+++ b/madbfs/src/filesystem.cpp
@@ -118,15 +118,6 @@ namespace madbfs
     AExpect<Ref<Node>> Filesystem::traverse_or_build(path::Path path)
     {
         if (path.is_root()) {
-            // workaround to initialize root stat on getattr
-            if (not m_root_initialized) {
-                auto stat = co_await m_connection.stat(path);
-                if (not stat.has_value()) {
-                    co_return Unexpect{ stat.error() };
-                }
-                m_root.set_stat(*stat);
-                m_root_initialized = true;
-            }
             co_return m_root;
         }
 
@@ -877,6 +868,19 @@ namespace madbfs
         auto node = std::make_unique<Node>(name, &parent->get(), std::move(stat), std::move(link));
 
         return dir.insert(std::move(node), false).transform(sink_void);
+    }
+
+    AExpect<void> Filesystem::initialize_root()
+    {
+        if (not std::exchange(m_root_initialized, true)) {
+            if (auto stat = co_await m_connection.stat(path::Path{}); stat.has_value()) {
+                m_root.set_stat(*stat);
+            } else {
+                co_return Unexpect{ stat.error() };
+            }
+        }
+
+        co_return Expect<void>{};
     }
 
     Await<void> Filesystem::shutdown()

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -310,14 +310,14 @@ namespace madbfs
     Expect<path::PathBuf> Madbfs::create_path(const char* path)
     {
         if (m_root.is_root()) {
-            return ok_or(path::create_buf(path), Errc::operation_not_supported);
+            return ok_or(path::create_buf(path), Errc::invalid_argument);
         }
 
         auto str = String{ m_root.str() };
         str.ends_with('/') ? void() : str.push_back('/');
         str.append(path);
 
-        return ok_or(path::create_buf(std::move(str)), Errc::operation_not_supported);
+        return ok_or(path::create_buf(std::move(str)), Errc::invalid_argument);
     }
 
     AExpect<json::value> Madbfs::ipc_handler(ipc::FsOp op)

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -277,11 +277,15 @@ namespace madbfs
         m_signal.async_wait([this, pid = ::getpid()](net::error_code ec, int sig) {
             if (not ec) {
                 assert(m_fuse != nullptr);
-                madbfs::log_w("Madbfs", "signal raised: SIG{} ({})", ::sigabbrev_np(sig), sig);
+                log_w("Madbfs", "signal raised: SIG{} ({})", ::sigabbrev_np(sig), sig);
                 ::fuse_exit(m_fuse);
                 ::kill(pid, SIGPIPE);
             }
         });
+
+        if (auto result = async::block(m_async_ctx, m_fs.initialize_root()); not result) {
+            log_c(__func__, "Failed to initialize root");
+        }
     }
 
     Madbfs::~Madbfs()

--- a/madbfs/src/madbfs.cpp
+++ b/madbfs/src/madbfs.cpp
@@ -307,17 +307,53 @@ namespace madbfs
         m_work_thread.join();
     }
 
-    Expect<path::PathBuf> Madbfs::create_path(const char* path)
+    Expect<path::Path> Madbfs::create_path(const char* path)
     {
+        thread_local static auto string = String{};
+        thread_local static auto comps  = Vec<util::Slice>{};
+
         if (m_root.is_root()) {
-            return ok_or(path::create_buf(path), Errc::invalid_argument);
+            return ok_or(path::create_with(comps, path), Errc::invalid_argument);
         }
 
-        auto str = String{ m_root.str() };
-        str.ends_with('/') ? void() : str.push_back('/');
-        str.append(path);
+        string.clear();
+        string.assign(m_root.str());
+        string.ends_with('/') ? void() : string.push_back('/');
+        string.append(path);
 
-        return ok_or(path::create_buf(std::move(str)), Errc::invalid_argument);
+        return ok_or(path::create_with(comps, string), Errc::invalid_argument);
+    }
+
+    Expect<Array<path::Path, 2>> Madbfs::create_path2(const char* path1, const char* path2)
+    {
+        thread_local static auto strings = Array<String, 2>{};
+        thread_local static auto compss  = Array<Vec<util::Slice>, 2>{};
+
+        auto paths  = Array{ path1, path2 };
+        auto result = Array<path::Path, 2>{};
+
+        for (auto i : sv::iota(0uz, 2uz)) {
+            if (m_root.is_root()) {
+                auto path = path::create_with(compss[i], paths[i]);
+                if (not path) {
+                    return Unexpect{ Errc::invalid_argument };
+                }
+                result[i] = std::move(*path);
+            }
+
+            strings[i].clear();
+            strings[i].assign(m_root.str());
+            strings[i].ends_with('/') ? void() : strings[i].push_back('/');
+            strings[i].append(paths[i]);
+
+            auto path = path::create_with(compss[i], strings[i]);
+            if (not path) {
+                return Unexpect{ Errc::invalid_argument };
+            }
+            result[i] = std::move(*path);
+        }
+
+        return std::move(result);
     }
 
     AExpect<json::value> Madbfs::ipc_handler(ipc::FsOp op)

--- a/madbfs/src/operations.cpp
+++ b/madbfs/src/operations.cpp
@@ -84,7 +84,7 @@ namespace
             case std::errc::read_only_file_system:
             case std::errc::filename_too_long:
             case std::errc::invalid_argument: {
-                if (madbfs::log::get_level() == madbfs::log::Level::debug) {
+                if (madbfs::log::get_level() <= madbfs::log::Level::debug) {
                     const auto& msg = madbfs::err_msg(err);
                     log(Level::warn, "{:?} returned with error code [{}]: {}", path, errint, msg);
                 }
@@ -96,6 +96,49 @@ namespace
             }
             return -errint;
         };
+    }
+
+    /**
+     * @brief Resolve then store symlink target into buf.
+     *
+     * @param buf Output buffer.
+     * @param target Symlink target.
+     *
+     * @return Nothing if success Errc if failure.
+     *
+     * This function resolves the symlink by prepending the mountpoint to the target if the symlink target is
+     * absolute. It only stores the target if the target is relative.
+     */
+    madbfs::Expect<void> resolve_symlink(madbfs::Span<char> buf, madbfs::Str target)
+    {
+        using namespace madbfs;
+
+        if (target.size() < 1) {
+            return Unexpect{ Errc::invalid_argument };
+        }
+
+        // custom root may break symlinks since the path pointed by the link might be unreachable, do I need
+        // to handle this special case? currently I'm too lazy to think, so I'll just let it be.
+
+        if (target[0] == '/') {    // absolute link
+            auto mount = get_data().mountpoint();
+            if (auto pathsize = mount.size() + target.size() + 1; pathsize > buf.size()) {
+                log_e(__func__, "path size is too long: {} vs {}", buf.size(), pathsize);
+                return Unexpect{ Errc::filename_too_long };
+            }
+            std::memcpy(buf.data(), mount.data(), mount.size());
+            std::memcpy(buf.data() + mount.size(), target.data(), target.size());
+            buf[mount.size() + target.size()] = '\0';
+        } else {
+            if (auto pathsize = target.size(); pathsize + 1 > buf.size()) {
+                log_e(__func__, "path size is too long: {} vs {}", buf.size(), pathsize);
+                return Unexpect{ Errc::filename_too_long };
+            }
+            std::memcpy(buf.data(), target.data(), target.size());
+            buf[target.size()] = '\0';
+        }
+
+        return {};
     }
 }
 
@@ -189,31 +232,7 @@ namespace madbfs::operations
         return get_data()
             .create_path(path)
             .and_then([](path::PathBuf p) { return invoke_fs(&Filesystem::readlink, p); })
-            .and_then([&](Str target) -> Expect<void> {
-                if (target.size() < 1) {
-                    return Unexpect{ Errc::invalid_argument };
-                }
-
-                if (target[0] == '/') {    // absolute link
-                    auto mount = get_data().mountpoint();
-                    if (auto pathsize = mount.size() + target.size() + 1; pathsize > size) {
-                        log_e(__func__, "path size is too long: {} vs {}", size, pathsize);
-                        return Unexpect{ Errc::filename_too_long };
-                    }
-                    std::memcpy(buf, mount.data(), mount.size());
-                    std::memcpy(buf + mount.size(), target.data(), target.size());
-                    buf[mount.size() + target.size()] = '\0';
-                } else {
-                    if (auto pathsize = target.size(); pathsize + 1 > size) {
-                        log_e(__func__, "path size is too long: {} vs {}", size, pathsize);
-                        return Unexpect{ Errc::filename_too_long };
-                    }
-                    std::memcpy(buf, target.data(), target.size());
-                    buf[target.size()] = '\0';
-                }
-
-                return {};
-            })
+            .and_then([&](Str target) { return resolve_symlink({ buf, size }, target); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }

--- a/madbfs/src/operations.cpp
+++ b/madbfs/src/operations.cpp
@@ -196,7 +196,7 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?}", path);
 
-        auto named_stat = get_data().create_path(path).and_then([](path::PathBuf p) {
+        auto named_stat = get_data().create_path(path).and_then([](path::Path p) {
             return invoke_fs(&Filesystem::getattr, p);
         });
         if (not named_stat.has_value()) {
@@ -231,7 +231,7 @@ namespace madbfs::operations
 
         return get_data()
             .create_path(path)
-            .and_then([](path::PathBuf p) { return invoke_fs(&Filesystem::readlink, p); })
+            .and_then([](path::Path p) { return invoke_fs(&Filesystem::readlink, p); })
             .and_then([&](Str target) { return resolve_symlink({ buf, size }, target); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
@@ -243,7 +243,7 @@ namespace madbfs::operations
 
         return get_data()
             .create_path(path)
-            .and_then([=](path::PathBuf p) { return invoke_fs(&Filesystem::mknod, p, mode, dev); })
+            .and_then([=](path::Path p) { return invoke_fs(&Filesystem::mknod, p, mode, dev); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -254,7 +254,7 @@ namespace madbfs::operations
 
         return get_data()
             .create_path(path)
-            .and_then([=](path::PathBuf p) { return invoke_fs(&Filesystem::mkdir, p, mode | S_IFDIR); })
+            .and_then([=](path::Path p) { return invoke_fs(&Filesystem::mkdir, p, mode | S_IFDIR); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -265,7 +265,7 @@ namespace madbfs::operations
 
         return get_data()
             .create_path(path)
-            .and_then([](path::PathBuf p) { return invoke_fs(&Filesystem::unlink, p); })
+            .and_then([](path::Path p) { return invoke_fs(&Filesystem::unlink, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -276,7 +276,7 @@ namespace madbfs::operations
 
         return get_data()
             .create_path(path)
-            .and_then([](path::PathBuf p) { return invoke_fs(&Filesystem::rmdir, p); })
+            .and_then([](path::Path p) { return invoke_fs(&Filesystem::rmdir, p); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -286,17 +286,9 @@ namespace madbfs::operations
     {
         log_i(__func__, "{:?} -> {:?} [flags={}]", from, to, flags);
 
-        auto from_path = get_data().create_path(from);
-        auto to_path   = get_data().create_path(to);
-
-        if (not from_path.has_value()) {
-            return fuse_err(__func__, from)(Errc::operation_not_supported);
-        }
-        if (not to_path.has_value()) {
-            return fuse_err(__func__, to)(Errc::operation_not_supported);
-        }
-
-        return invoke_fs(&Filesystem::rename, *from_path, *to_path, flags)
+        return get_data()
+            .create_path2(from, to)
+            .and_then([&](auto p) { return invoke_fs(&Filesystem::rename, p[0], p[1], flags); })
             .transform_error(fuse_err(__func__, from))
             .error_or(0);
     }
@@ -307,7 +299,7 @@ namespace madbfs::operations
 
         return get_data()
             .create_path(path)
-            .and_then([&](path::PathBuf p) { return invoke_fs(&Filesystem::truncate, p, size); })
+            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::truncate, p, size); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -318,7 +310,7 @@ namespace madbfs::operations
 
         return get_data()
             .create_path(path)
-            .and_then([&](path::PathBuf p) { return invoke_fs(&Filesystem::open, p, fi->flags); })
+            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::open, p, fi->flags); })
             .transform([&](u64 fd) { fi->fh = fd; })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
@@ -371,7 +363,7 @@ namespace madbfs::operations
 
         return get_data()
             .create_path(path)
-            .and_then([&](path::PathBuf p) { return invoke_fs(&Filesystem::readdir, p, fill); })
+            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::readdir, p, fill); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -387,7 +379,7 @@ namespace madbfs::operations
 
         return get_data()
             .create_path(path)
-            .and_then([&](path::PathBuf p) { return invoke_fs(&Filesystem::utimens, p, tv[0], tv[1]); })
+            .and_then([&](path::Path p) { return invoke_fs(&Filesystem::utimens, p, tv[0], tv[1]); })
             .transform_error(fuse_err(__func__, path))
             .error_or(0);
     }
@@ -407,17 +399,10 @@ namespace madbfs::operations
             __func__, "[size={}] | {:?} [off={}] -> {:?} [off={}]", size, in_path, in_off, out_path, out_off
         );
 
-        auto in  = path::create(in_path);
-        auto out = path::create(out_path);
-
-        if (not in) {
-            return fuse_err(__func__, in_path)(Errc::operation_not_supported);
-        } else if (not out) {
-            return fuse_err(__func__, out_path)(Errc::operation_not_supported);
-        }
-
-        auto op  = &Filesystem::copy_file_range;
-        auto res = invoke_fs(op, *in, in_fi->fh, in_off, *out, out_fi->fh, out_off, size);
+        auto res = get_data().create_path2(in_path, out_path).and_then([&](auto p) {
+            auto op = &Filesystem::copy_file_range;
+            return invoke_fs(op, p[0], in_fi->fh, in_off, p[1], out_fi->fh, out_off, size);
+        });
         return res ? static_cast<isize>(res.value()) : fuse_err(__func__, in_path)(res.error());
     }
 }

--- a/madbfs/src/path.cpp
+++ b/madbfs/src/path.cpp
@@ -7,18 +7,21 @@ namespace madbfs::path
     /**
      * @brief Split path string into its components.
      *
+     * @param comps_buf Path components storage.
      * @param path Input path string.
      *
-     * @return A pair of the components and a cleaned version of the path (extra '/' are stripped from the
-     * beginning and the end of the path).
+     * @return A cleaned version of the path (extra '/' are stripped from the beginning and the end of the
+     * path).
      *
      * The components and the cleaned path are in index-based slice instead of string view.
      */
-    Opt<Pair<Vec<Slice>, Slice>> split_components(Str path)
+    Opt<Slice> split_components(Vec<Slice>& comps_buf, Str path)
     {
         if (path.empty() or path.front() != '/') {
             return std::nullopt;
         }
+
+        comps_buf.clear();
 
         while (path.size() > 1 and path.back() == '/') {
             path.remove_suffix(1);
@@ -31,11 +34,10 @@ namespace madbfs::path
         }
 
         if (path == "/") {
-            return Pair{ Vec<Slice>{}, Slice{} };
+            return Slice{};
         }
 
-        auto components = Vec<Slice>{};
-        auto index      = 1uz;
+        auto index = 1uz;
 
         while (index < path.size()) {
             auto current = index;
@@ -45,15 +47,15 @@ namespace madbfs::path
 
             auto next = path.find('/', current);
             if (next == Str::npos) {
-                components.emplace_back(current, path.size() - current);
+                comps_buf.emplace_back(current, path.size() - current);
                 break;
             }
 
-            components.emplace_back(current, next - current);
+            comps_buf.emplace_back(current, next - current);
             index = next;
         }
 
-        return Pair{ std::move(components), Slice{ offset_prefix, path.size() } };
+        return Slice{ offset_prefix, path.size() };
     }
 }
 
@@ -166,45 +168,61 @@ namespace madbfs::path
 {
     Opt<SemiPath> create(Str path)
     {
-        auto split = split_components(path);
-        if (not split) {
+        auto comps = Vec<Slice>{};
+        auto slice = split_components(comps, path);
+        if (not slice) {
             return std::nullopt;
         }
 
-        auto&& [comps, slice] = *split;
         if (comps.empty()) {
             return SemiPath{};
         }
 
-        auto path_path = Path{ slice.to_str(path), comps };
+        auto path_path = Path{ slice->to_str(path), comps };
         return SemiPath{ std::move(comps), std::move(path_path) };
     }
 
     Opt<PathBuf> create_buf(String&& path_str)
     {
-        auto split = split_components(path_str);
-        if (not split) {
+        auto comps = Vec<Slice>{};
+        auto slice = split_components(comps, path_str);
+        if (not slice) {
             return std::nullopt;
         }
 
-        auto&& [comps, slice] = *split;
         if (comps.empty()) {
             path_str = "/";
         } else {
-            slice.keep_slice(path_str);
+            slice->keep_slice(path_str);
         }
 
         return PathBuf{ std::move(path_str), std::move(comps) };
     }
 
-    PathBuf resolve(madbfs::path::Path parent, madbfs::Str path)
+    Opt<Path> create_with(Vec<Slice>& comps_buf, Str path)
     {
-        auto parents = madbfs::Vec<madbfs::Str>{};
-        if (path.front() != '/') {
-            parents = madbfs::util::split(parent.str(), '/');
+        auto slice = split_components(comps_buf, path);
+        if (not slice) {
+            return std::nullopt;
         }
 
-        madbfs::util::StringSplitter{ path, '/' }.while_next([&](madbfs::Str str) {
+        if (comps_buf.empty()) {
+            return Path{};
+        }
+
+        return Path{ slice->to_str(path), comps_buf };
+    }
+
+    PathBuf resolve(Path parent, Str path)
+    {
+        assert(not path.empty());
+
+        auto parents = Vec<Str>{};
+        if (path.front() != '/') {
+            parents = util::split(parent.str(), '/');
+        }
+
+        util::StringSplitter{ path, '/' }.while_next([&](Str str) {
             if (str == ".") {
                 return;
             } else if (str == "..") {
@@ -220,7 +238,7 @@ namespace madbfs::path
             return PathBuf{};
         }
 
-        auto resolved = madbfs::String{};
+        auto resolved = String{};
         for (auto path : parents) {
             resolved += '/';
             resolved += path;

--- a/madbfs/src/path.cpp
+++ b/madbfs/src/path.cpp
@@ -59,6 +59,23 @@ namespace madbfs::path
 
 namespace madbfs::path
 {
+    Str Path::parent() const
+    {
+        if (is_root() or m_components.size() == 1) {
+            return "/";
+        }
+
+        const auto parent = m_components[m_components.size() - 2];
+        const auto size   = parent.offset + parent.size;
+
+        return { m_path.data(), size };
+    }
+
+    Path Path::parent_path() const
+    {
+        return is_root() ? *this : Path{ parent(), { m_components.begin(), m_components.size() - 1 } };
+    }
+
     Opt<PathBuf> Path::extend_copy(Str name) const
     {
         if (name.contains('/')) {
@@ -81,6 +98,23 @@ namespace madbfs::path
 
 namespace madbfs::path
 {
+    Str PathBuf::parent() const
+    {
+        if (is_root() or m_components.size() == 1) {
+            return "/";
+        }
+
+        const auto parent = m_components[m_components.size() - 2];
+        const auto size   = parent.offset + parent.size;
+
+        return { m_path.data(), size };
+    }
+
+    Path PathBuf::parent_path() const
+    {
+        return is_root() ? *this : Path{ parent(), { m_components.begin(), m_components.size() - 1 } };
+    }
+
     bool PathBuf::rename(Str name)
     {
         if (name.empty() or name.contains('/') or name == "." or name == "..") {

--- a/test/test_path.cpp
+++ b/test/test_path.cpp
@@ -278,8 +278,10 @@ int main()
     using ut::expect, ut::log, ut::that, ut::throws;
 
     using madbfs::path::create;
+    using madbfs::path::create_with;
     using madbfs::path::operator""_path;
     using madbfs::path::PathBuf;
+    using madbfs::util::Slice;
 
     "Path must be correctly constructed"_test = [](const TestConstruct& test) {
         auto comp_path = create(test.input);
@@ -374,4 +376,25 @@ int main()
                 << "Address should be different: " << test;
         }
     } | constructible_testcases;
+
+    "Path constructed using existing buffer should have the same components"_test = [] {
+        auto path_str  = "/home/user/projects/cpp/madbfs";
+        auto comps_buf = Vec<Slice>{};
+
+        auto path = create_with(comps_buf, path_str);
+        expect(path.has_value() >> ut::fatal);
+
+        expect(path->parent() == "/home/user/projects/cpp");
+        expect(path->filename() == "madbfs");
+        expect(path->str() == path_str);
+
+        auto path2 = create(path_str);
+        expect(path2.has_value() >> ut::fatal);
+
+        expect(path2->path.parent() == "/home/user/projects/cpp");
+        expect(path2->path.filename() == "madbfs");
+        expect(path2->path.str() == path_str);
+
+        expect(std::ranges::equal(path->iter(), path2->path.iter()));
+    };
 }


### PR DESCRIPTION
- Fix custom root path not using canonical path
- Return EINVAL on malformed path instead of EOPNOTSUPP
- Use TLS scratch buffer for path translation effectively eliminating the need for allocation for translated paths per operation