### PR TITLE
x86_64-baseline build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
     - name: Checkout code
@@ -27,7 +27,7 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.10
 
     - name: Configure C++ development tools
-      run: sudo apt-get install cmake ninja-build clang-20
+      run: sudo apt-get install cmake ninja-build clang-22
 
     - name: Setup Android NDK
       uses: nttld/setup-ndk@v1
@@ -40,8 +40,8 @@ jobs:
       env:
         ANDROID_NDK_HOME: "${{ steps.setup-ndk.outputs.ndk-path }}"
         SCCACHE_GHA_ENABLED: true
-        CC: "/usr/bin/clang-20"
-        CXX: "/usr/bin/clang++-20"
+        CC: "/usr/bin/clang-22"
+        CXX: "/usr/bin/clang++-22"
         CMAKE_C_COMPILER_LAUNCHER: "sccache"
         CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code
@@ -27,7 +27,7 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.10
 
     - name: Configure C++ development tools
-      run: sudo apt-get install cmake ninja-build
+      run: sudo apt-get install cmake ninja-build clang-20
 
     - name: Setup Android NDK
       uses: nttld/setup-ndk@v1
@@ -40,6 +40,8 @@ jobs:
       env:
         ANDROID_NDK_HOME: "${{ steps.setup-ndk.outputs.ndk-path }}"
         SCCACHE_GHA_ENABLED: true
+        CC: "/usr/bin/clang-20"
+        CXX: "/usr/bin/clang++-20"
         CMAKE_C_COMPILER_LAUNCHER: "sccache"
         CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
 

--- a/.github/workflows/profile-client.ini
+++ b/.github/workflows/profile-client.ini
@@ -9,3 +9,5 @@ os=Linux
 
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
+tools.build:cxxflags=["-march=x86-64"]
+tools.build:cflags=["-march=x86-64"]

--- a/.github/workflows/profile-client.ini
+++ b/.github/workflows/profile-client.ini
@@ -4,9 +4,9 @@ build_type=Release
 compiler=clang
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=20
+compiler.version=22
 os=Linux
 
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
-tools.build:compiler_executables={'c':'/usr/bin/clang-20','cpp':'/usr/bin/clang++-20'}
+tools.build:compiler_executables={'c':'/usr/bin/clang-22','cpp':'/usr/bin/clang++-22'}

--- a/.github/workflows/profile-client.ini
+++ b/.github/workflows/profile-client.ini
@@ -1,13 +1,12 @@
 [settings]
 arch=x86_64
 build_type=Release
-compiler=gcc
+compiler=clang
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=15
+compiler.version=20
 os=Linux
 
 [conf]
 tools.cmake.cmaketoolchain:generator=Ninja
-tools.build:cxxflags=["-march=x86-64"]
-tools.build:cflags=["-march=x86-64"]
+tools.build:compiler_executables={'c':'/usr/bin/clang-20','cpp':'/usr/bin/clang++-20'}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project(
 option(MADBFS_ENABLE_TESTS "Enable tests" ON)
 option(MADBFS_AUTORUN_TESTS "Automatically ran tests" OFF)
 option(MADBFS_BUILD_DOCS "Build docs" OFF)
+option(MADBFS_BUILD_TARGET_BASELINE "Build target x86_64-baseline" ON)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -23,6 +24,15 @@ set(CMAKE_SKIP_RPATH TRUE)  # stop injecting RPATH for conan deps
 set(MADBFS_USE_NON_BOOST_ASIO OFF CACHE BOOL "use non-boost asio")
 set(MADBFS_ENABLE_RAPIDHASH_BLANKET_IMPL ON CACHE BOOL "enable rapidhash")
 set(MADBFS_BUILD_IPC ON CACHE BOOL "build ipc")
+
+if(MADBFS_BUILD_TARGET_BASELINE AND CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-march=x86-64)
+    message(STATUS "madbfs: Build targeting x86_64-baseline")
+  else()
+    message(FATAL_ERROR "Currently only supporting GNU/Clang for this target")
+  endif()
+endif()
 
 add_subdirectory(madbfs-common)
 add_subdirectory(madbfs)


### PR DESCRIPTION
Lower the build requirement for `x86_64` build of `madbfs`. This addresses issue #29